### PR TITLE
자동 머지 운영 거버넌스 추가

### DIFF
--- a/docs/AUTOMERGE_GOVERNANCE.md
+++ b/docs/AUTOMERGE_GOVERNANCE.md
@@ -1,0 +1,90 @@
+# 자동 머지 운영 거버넌스
+
+## 목적
+
+이 문서는 에이전트가 만든 PR을 자동으로 병합할 때의 운영 조건을 고정한다. 목표는 속도를 높이는 것이 아니라, 자동화가 사람의 개입 없이 반복되더라도 실패 범위와 중단 조건이 명확한 상태를 유지하는 것이다.
+
+## 현재 운영 모드
+
+현재 기본 모드는 `검증 자동화 + 수동/명시 승인 기반 병합`이다.
+
+`Agent Automerge Trial` workflow는 PR이 자동 머지 후보인지 판정하고 전체 검증을 실행한다. 실제 GitHub native auto-merge 요청은 저장소 변수 `ENABLE_AGENT_AUTOMERGE`가 `true`일 때만 실행된다.
+
+## Branch protection
+
+`main`에는 아래 required checks를 요구하는 Branch protection을 권장한다.
+
+| Required check | 출처 |
+| --- | --- |
+| `Verify game baseline` | `.github/workflows/ci.yml` |
+| `Check automerge eligibility` | `.github/workflows/agent-automerge.yml` |
+
+브랜치 보호가 없다면 `gh pr merge --auto`가 사실상 즉시 병합될 수 있다. 따라서 `ENABLE_AGENT_AUTOMERGE`를 켜기 전에 Branch protection과 required checks를 먼저 확인한다.
+
+## 자동 머지 후보 조건
+
+모든 조건이 맞아야 한다.
+
+- base branch가 `main`이다.
+- fork PR이 아니다.
+- PR이 draft가 아니다.
+- PR label에 `agent-automerge`가 있다.
+- head branch가 `codex/` 또는 `agent/`로 시작한다.
+- `npm run check:automerge`가 통과한다.
+- `npm run check:all`이 통과한다.
+- 저장소 변수 `ENABLE_AGENT_AUTOMERGE`가 `true`다.
+
+## 중단 조건
+
+아래 조건에서는 자동 머지 후보가 아니며, agent는 병합을 시도하지 않는다.
+
+- 제품 결제, 계정, 권한, credential, 실제 사용자 데이터와 관련된 변경
+- `Scope-risk: broad`
+- 테스트 또는 visual evidence 없이 UI를 바꾸는 변경
+- `main`이 아닌 base branch
+- fork PR
+- label이 없거나 branch prefix가 맞지 않는 PR
+- 실패한 check를 우회해야만 병합 가능한 PR
+
+## 저장소 변수 운영
+
+`ENABLE_AGENT_AUTOMERGE`는 기본적으로 꺼져 있어야 한다.
+
+켜기 전 확인:
+
+1. Branch protection이 `main`에 적용되어 있다.
+2. required checks가 `Verify game baseline`, `Check automerge eligibility`를 포함한다.
+3. 실패한 PR에서 auto-merge가 요청되지 않는지 테스트한다.
+4. audit report에 변경 시각과 이유를 기록한다.
+
+끄는 기준:
+
+- CI가 불안정하다.
+- 자동 머지 후보 판정이 잘못된 PR을 통과시킨다.
+- 에이전트가 scope-risk를 낮게 잘못 분류했다.
+- GitHub Actions 권한이나 브랜치 보호 설정이 변경됐다.
+
+## 운영 명령
+
+로컬 후보 판정:
+
+```bash
+GITHUB_EVENT_NAME=pull_request \
+PR_HEAD_REF=codex/example \
+PR_BASE_REF=main \
+PR_IS_FORK=false \
+PR_LABELS=agent-automerge \
+npm run check:automerge
+```
+
+정책 문서/워크플로 점검:
+
+```bash
+npm run check:governance
+```
+
+전체 점검:
+
+```bash
+npm run check:all
+```

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -15,20 +15,21 @@ Updated: 2026-04-27
 | PR 자동 검증 | verified | PR #1, PR #2 |
 | Apply gate | verified | `npm run check:apply` |
 | 대시보드 자동 갱신 | review | `npm run update:dashboard`, `npm run check:dashboard` |
+| 자동 머지 거버넌스 | review | `npm run check:governance` |
 
 ## 로드맵 요약
 
 | 상태 | 개수 |
 | --- | ---: |
 | done | 24 |
-| review | 5 |
+| review | 6 |
 | todo | 0 |
 | blocked | 0 |
 
 ## 다음 작업
 
-1. 브랜치 보호와 `ENABLE_AGENT_AUTOMERGE` 운영 정책을 문서화한다.
-2. PR 자동화 결과를 audit report에 누적한다.
+1. PR 자동화 결과를 audit report에 누적한다.
+2. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
 3. 다음 게임 기능 작업을 `items/` 단위로 등록한다.
 
 ## 검증 상태
@@ -41,10 +42,11 @@ Updated: 2026-04-27
 | `npm run check:docs` | tracked |
 | `npm run check:apply` | tracked |
 | `npm run check:dashboard` | tracked |
+| `npm run check:governance` | tracked |
 | `npm run build` | tracked |
 
 ## 열린 위험
 
-- `ENABLE_AGENT_AUTOMERGE` 저장소 변수와 브랜치 보호 규칙은 아직 명시적으로 고정하지 않았다.
+- `ENABLE_AGENT_AUTOMERGE` 저장소 변수와 Branch protection은 문서화됐지만 실제 GitHub 설정 변경은 별도 승인 대상이다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.

--- a/docs/PR_AUTOMATION.md
+++ b/docs/PR_AUTOMATION.md
@@ -11,6 +11,8 @@
 - `.github/workflows/ci.yml`: PR과 `main` push에서 전체 프로젝트 검증을 실행한다.
 - `.github/workflows/agent-automerge.yml`: PR이 자동 머지 후보인지 확인하고, 저장소 변수가 켜진 경우에만 GitHub native auto-merge를 요청한다.
 - `scripts/check-automerge-readiness.mjs`: 자동 머지 후보 조건을 로컬에서도 검증할 수 있게 만든다.
+- `docs/AUTOMERGE_GOVERNANCE.md`: Branch protection, required checks, 저장소 변수 운영 조건을 정의한다.
+- `scripts/check-governance.mjs`: 자동 머지 운영 정책과 workflow 핵심 문구가 유지되는지 확인한다.
 
 ## 자동 머지 후보 조건
 
@@ -31,12 +33,29 @@
 
 자동 머지는 GitHub native auto-merge 요청으로 제한한다. 즉시 강제 병합하지 않고, 브랜치 보호 규칙과 필수 체크가 있다면 그 규칙을 따른다.
 
+## Branch protection과 required checks
+
+저장소 변수 `ENABLE_AGENT_AUTOMERGE`를 켜기 전에 `main` Branch protection을 먼저 설정한다.
+
+권장 required checks:
+
+- `Verify game baseline`
+- `Check automerge eligibility`
+
+브랜치 보호 없이 `ENABLE_AGENT_AUTOMERGE`를 켜면 auto-merge 요청이 사실상 즉시 병합으로 이어질 수 있다. 따라서 자동 머지 활성화는 `docs/AUTOMERGE_GOVERNANCE.md`의 중단 조건과 저장소 변수 운영 기준을 따른다.
+
 ## 로컬 검증
 
 일반 검증:
 
 ```bash
 npm run check:all
+```
+
+정책 점검:
+
+```bash
+npm run check:governance
 ```
 
 자동 머지 후보 판정 예시:
@@ -55,4 +74,4 @@ npm run check:automerge
 - `items/` 작업 기록과 PR을 연결한다.
 - 자동 머지 실행 결과를 `reports/audits/`에 남긴다.
 - 브랜치 보호 규칙과 required checks를 GitHub 설정에서 명시한다.
-- 첫 실험 PR은 문서 또는 테스트 전용 변경으로 제한한다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜는 경우 audit report에 변경 시각과 이유를 남긴다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This folder is the durable memory for `이상한 씨앗상회` and the autonomou
 | `AUTONOMOUS_PROJECT_OPERATING_MODEL.md` | ClawSweeper-inspired agent operating model | Before automation/project-management work |
 | `BROWSER_QA.md` | Browser Use 기반 로컬 브라우저 검증 절차 | Before visual/mobile QA |
 | `PR_AUTOMATION.md` | PR 자동 검증과 제한적 자동 머지 정책 | Before CI/PR automation work |
+| `AUTOMERGE_GOVERNANCE.md` | 자동 머지 활성화 전 Branch protection과 변수 운영 조건 | Before changing GitHub merge settings |
 | `REPORTING.md` | 자율 작업 보고서와 감사 보고서 형식 | Before adding reports/items |
 | `APPLY_CONDITIONS.md` | 에이전트 적용 lane의 gate와 중단 조건 | Before applying autonomous changes |
 | `DASHBOARD.md` | 현재 상태, 다음 작업, 검증 상태 요약 | At the start/end of each milestone |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -82,6 +82,7 @@ Goal: make the project increasingly self-managing.
 | Create apply conditions | review | `docs/APPLY_CONDITIONS.md`, `scripts/check-apply-conditions.mjs` | Mutations require valid proposal + acceptance criteria |
 | Create audit report | review | `reports/audits/audit_20260427.md`, `scripts/check-docs-index.mjs` | Drift between docs, items, code, assets is detectable |
 | Create dashboard | review | `docs/DASHBOARD.md`, `scripts/update-dashboard.mjs` | Current status, next item, verification health visible and checkable |
+| Document automerge governance | review | `docs/AUTOMERGE_GOVERNANCE.md`, `scripts/check-governance.mjs` | Branch protection, required checks, and `ENABLE_AGENT_AUTOMERGE` operating rules are checkable |
 
 ## Current Next Action
 
@@ -89,4 +90,4 @@ Browser Use 기반 스크린샷 자동화, 핵심 클릭 플로우, 오프라인
 
 1. 이 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
 2. 자동 머지 trial을 통해 main에 반영한다.
-3. 다음 자동화 항목으로 브랜치 보호/`ENABLE_AGENT_AUTOMERGE` 운영 정책을 문서화한다.
+3. 다음 자동화 항목으로 PR 결과 audit 누적을 자동화한다.

--- a/items/0004-automerge-governance.md
+++ b/items/0004-automerge-governance.md
@@ -1,0 +1,45 @@
+# 자동 머지 운영 거버넌스
+
+Status: verified
+Owner: agent
+Created: 2026-04-27
+Updated: 2026-04-27
+Scope-risk: narrow
+
+## Intent
+
+PR 자동 머지 trial이 반복 가능해졌으므로, 저장소 변수와 브랜치 보호 규칙을 켜기 전에 운영 조건과 중단 조건을 문서와 점검 스크립트로 고정한다.
+
+## Acceptance Criteria
+
+- 자동 머지 운영 정책 문서가 존재한다.
+- `ENABLE_AGENT_AUTOMERGE`, `agent-automerge`, required checks, Branch protection 조건이 문서화된다.
+- 정책 문서와 workflow 핵심 조건을 확인하는 로컬 점검 명령이 있다.
+- `npm run check:all`이 governance check를 포함한다.
+
+## Evidence
+
+- `docs/AUTOMERGE_GOVERNANCE.md`
+- `docs/PR_AUTOMATION.md`
+- `scripts/check-governance.mjs`
+- 2026-04-27: `npm run check:governance` 통과
+- 2026-04-27: `npm run check:all` 통과
+
+## Proposed Plan
+
+- 자동 머지 운영 문서를 추가한다.
+- 기존 PR 자동화 문서에 Branch protection과 required checks를 명시한다.
+- governance check 스크립트를 추가한다.
+- 전체 검증에 governance check를 포함한다.
+- PR 단위로 GitHub Actions 검증과 자동 머지 trial을 반복한다.
+
+## Apply Conditions
+
+- 실제 저장소 변수나 Branch protection 설정은 이 PR에서 변경하지 않는다.
+- GitHub 설정 변경은 별도 action-time 승인과 audit report가 필요하다.
+
+## Verification
+
+- `npm run check:governance`
+- `npm run check:all`
+- `GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/automerge-governance PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:dashboard": "node scripts/update-dashboard.mjs --check",
     "capture:local": "node scripts/capture-local-screenshot.mjs",
     "check:automerge": "node scripts/check-automerge-readiness.mjs",
-    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run build"
+    "check:governance": "node scripts/check-governance.mjs",
+    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:governance && npm run build"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/scripts/check-apply-conditions.mjs
+++ b/scripts/check-apply-conditions.mjs
@@ -9,6 +9,7 @@ const requiredPaths = [
   "items/0001-pr-automation-trial.md",
   "items/0002-dashboard-auto-update.md",
   "items/0003-browser-offline-desktop-qa.md",
+  "items/0004-automerge-governance.md",
   "reports/audits/audit_20260427.md",
   "reports/reviews/README.md"
 ];

--- a/scripts/check-docs-index.mjs
+++ b/scripts/check-docs-index.mjs
@@ -8,6 +8,7 @@ const requiredDocs = [
   "docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md",
   "docs/BROWSER_QA.md",
   "docs/PR_AUTOMATION.md",
+  "docs/AUTOMERGE_GOVERNANCE.md",
   "docs/REPORTING.md",
   "docs/APPLY_CONDITIONS.md",
   "docs/DASHBOARD.md"

--- a/scripts/check-governance.mjs
+++ b/scripts/check-governance.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+
+const requiredPaths = [
+  ".github/workflows/ci.yml",
+  ".github/workflows/agent-automerge.yml",
+  "docs/PR_AUTOMATION.md",
+  "docs/AUTOMERGE_GOVERNANCE.md",
+  "items/0004-automerge-governance.md"
+];
+
+const requiredPhrases = new Map([
+  [
+    "docs/AUTOMERGE_GOVERNANCE.md",
+    [
+      "ENABLE_AGENT_AUTOMERGE",
+      "agent-automerge",
+      "required checks",
+      "Branch protection",
+      "중단 조건"
+    ]
+  ],
+  [
+    "docs/PR_AUTOMATION.md",
+    [
+      "저장소 변수 `ENABLE_AGENT_AUTOMERGE`",
+      "Branch protection",
+      "required checks",
+      "agent-automerge"
+    ]
+  ],
+  [
+    ".github/workflows/agent-automerge.yml",
+    [
+      "ENABLE_AGENT_AUTOMERGE",
+      "npm run check:automerge",
+      "npm run check:all",
+      "gh pr merge"
+    ]
+  ],
+  [
+    ".github/workflows/ci.yml",
+    [
+      "npm run check:all"
+    ]
+  ]
+]);
+
+const failures = [];
+
+for (const path of requiredPaths) {
+  if (!fs.existsSync(path)) {
+    failures.push(`missing required path: ${path}`);
+  }
+}
+
+for (const [path, phrases] of requiredPhrases.entries()) {
+  if (!fs.existsSync(path)) {
+    continue;
+  }
+
+  const content = fs.readFileSync(path, "utf8");
+  for (const phrase of phrases) {
+    if (!content.includes(phrase)) {
+      failures.push(`${path} missing phrase: ${phrase}`);
+    }
+  }
+}
+
+console.log(
+  JSON.stringify(
+    {
+      ok: failures.length === 0,
+      requiredPaths: requiredPaths.length,
+      phraseGroups: requiredPhrases.size,
+      failures
+    },
+    null,
+    2
+  )
+);
+
+if (failures.length > 0) {
+  process.exit(1);
+}

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -33,7 +33,8 @@ const rows = [
   ["브라우저 QA", stepStatus("Visual/mobile QA", "review"), "`reports/visual/browser_use_qa_20260427.md`"],
   ["PR 자동 검증", fileStatus([".github/workflows/ci.yml", ".github/workflows/agent-automerge.yml"]), "PR #1, PR #2"],
   ["Apply gate", fileStatus(["docs/APPLY_CONDITIONS.md", "scripts/check-apply-conditions.mjs"]), "`npm run check:apply`"],
-  ["대시보드 자동 갱신", stepStatus("Create dashboard", "review"), "`npm run update:dashboard`, `npm run check:dashboard`"]
+  ["대시보드 자동 갱신", stepStatus("Create dashboard", "review"), "`npm run update:dashboard`, `npm run check:dashboard`"],
+  ["자동 머지 거버넌스", stepStatus("Document automerge governance", "review"), "`npm run check:governance`"]
 ];
 
 const commands = [
@@ -43,6 +44,7 @@ const commands = [
   "npm run check:docs",
   "npm run check:apply",
   "npm run check:dashboard",
+  "npm run check:governance",
   "npm run build"
 ];
 
@@ -70,8 +72,8 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 
 ## 다음 작업
 
-1. 브랜치 보호와 \`ENABLE_AGENT_AUTOMERGE\` 운영 정책을 문서화한다.
-2. PR 자동화 결과를 audit report에 누적한다.
+1. PR 자동화 결과를 audit report에 누적한다.
+2. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
 3. 다음 게임 기능 작업을 \`items/\` 단위로 등록한다.
 
 ## 검증 상태
@@ -82,7 +84,7 @@ ${commands.map((command) => `| \`${command}\` | tracked |`).join("\n")}
 
 ## 열린 위험
 
-- \`ENABLE_AGENT_AUTOMERGE\` 저장소 변수와 브랜치 보호 규칙은 아직 명시적으로 고정하지 않았다.
+- \`ENABLE_AGENT_AUTOMERGE\` 저장소 변수와 Branch protection은 문서화됐지만 실제 GitHub 설정 변경은 별도 승인 대상이다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.
 `;


### PR DESCRIPTION
## 목적

반복된 PR 자동화 실험을 실제 운영으로 확대하기 전에 Branch protection, required checks, ENABLE_AGENT_AUTOMERGE 운영 기준을 문서화하고 검증 가능하게 만듭니다.

## 변경

- 자동 머지 거버넌스 문서 추가
- PR 자동화 정책에 Branch protection / required checks 명시
- governance check 스크립트 추가
- check:all에 check:governance 포함
- dashboard, roadmap, item 기록 갱신

## 검증

- npm run check:governance
- npm run check:all
- GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/automerge-governance PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge

## 자동화 실험 조건

- branch: codex/automerge-governance
- label: agent-automerge
- base: main
- fork: false

실제 GitHub Branch protection 또는 ENABLE_AGENT_AUTOMERGE 설정은 이 PR에서 변경하지 않습니다.