### PR TITLE
PR 자동화 결과 audit 누적

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -16,20 +16,21 @@ Updated: 2026-04-27
 | Apply gate | verified | `npm run check:apply` |
 | 대시보드 자동 갱신 | review | `npm run update:dashboard`, `npm run check:dashboard` |
 | 자동 머지 거버넌스 | review | `npm run check:governance` |
+| PR 자동화 audit | review | `npm run check:audit` |
 
 ## 로드맵 요약
 
 | 상태 | 개수 |
 | --- | ---: |
 | done | 24 |
-| review | 6 |
+| review | 7 |
 | todo | 0 |
 | blocked | 0 |
 
 ## 다음 작업
 
-1. PR 자동화 결과를 audit report에 누적한다.
-2. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
+1. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
+2. PR 결과 audit을 `gh` 조회 기반으로 생성하는 스크립트를 추가한다.
 3. 다음 게임 기능 작업을 `items/` 단위로 등록한다.
 
 ## 검증 상태
@@ -43,6 +44,7 @@ Updated: 2026-04-27
 | `npm run check:apply` | tracked |
 | `npm run check:dashboard` | tracked |
 | `npm run check:governance` | tracked |
+| `npm run check:audit` | tracked |
 | `npm run build` | tracked |
 
 ## 열린 위험

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,3 +56,5 @@ The project should move toward a ClawSweeper-style autonomous model:
 - audit lane detects drift
 
 Until the richer item system exists, `ROADMAP.md` is the tracking surface.
+
+Current PR automation audit evidence is stored in `reports/audits/pr_automation_20260427.md`.

--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -65,3 +65,5 @@ Status: pass | warn | fail
 `npm run update:dashboard`는 로드맵과 주요 파일 존재 여부를 기준으로 `docs/DASHBOARD.md`를 다시 생성한다.
 
 `npm run check:dashboard`는 생성 결과와 현재 `docs/DASHBOARD.md`가 일치하는지 확인한다.
+
+`npm run check:audit`는 필수 audit report와 PR 자동화 결과 기록이 존재하는지 확인한다.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,6 +83,7 @@ Goal: make the project increasingly self-managing.
 | Create audit report | review | `reports/audits/audit_20260427.md`, `scripts/check-docs-index.mjs` | Drift between docs, items, code, assets is detectable |
 | Create dashboard | review | `docs/DASHBOARD.md`, `scripts/update-dashboard.mjs` | Current status, next item, verification health visible and checkable |
 | Document automerge governance | review | `docs/AUTOMERGE_GOVERNANCE.md`, `scripts/check-governance.mjs` | Branch protection, required checks, and `ENABLE_AGENT_AUTOMERGE` operating rules are checkable |
+| Accumulate PR automation audit | review | `reports/audits/pr_automation_20260427.md`, `scripts/check-audit-reports.mjs` | PR #1-#5 automation results are preserved and checkable |
 
 ## Current Next Action
 
@@ -90,4 +91,4 @@ Browser Use 기반 스크린샷 자동화, 핵심 클릭 플로우, 오프라인
 
 1. 이 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
 2. 자동 머지 trial을 통해 main에 반영한다.
-3. 다음 자동화 항목으로 PR 결과 audit 누적을 자동화한다.
+3. 다음 자동화 항목으로 GitHub Branch protection 설정 여부를 audit한다.

--- a/items/0005-pr-automation-audit.md
+++ b/items/0005-pr-automation-audit.md
@@ -1,0 +1,44 @@
+# PR 자동화 결과 audit 누적
+
+Status: verified
+Owner: agent
+Created: 2026-04-27
+Updated: 2026-04-27
+Scope-risk: narrow
+
+## Intent
+
+PR #1부터 PR #5까지 반복한 자동 체크와 자동 머지 trial 결과를 audit report로 남겨, 자동화가 실제 저장소에서 반복 가능하게 동작했다는 근거를 보존한다.
+
+## Acceptance Criteria
+
+- PR 자동화 결과 audit report가 존재한다.
+- PR #1부터 PR #5까지의 상태와 증거가 기록된다.
+- audit report 누락을 잡는 로컬 점검 명령이 있다.
+- `npm run check:all`에 audit check가 포함된다.
+
+## Evidence
+
+- `reports/audits/pr_automation_20260427.md`
+- `scripts/check-audit-reports.mjs`
+- 2026-04-27: `gh pr list --state all`에서 PR #1-#5가 `MERGED`로 확인됨
+- 2026-04-27: `npm run check:audit` 통과
+- 2026-04-27: `npm run check:all` 통과
+
+## Proposed Plan
+
+- PR 자동화 audit report를 추가한다.
+- audit report 필수 문구 점검 스크립트를 추가한다.
+- 전체 검증에 audit check를 포함한다.
+- PR 단위로 GitHub Actions와 자동 머지 trial을 반복한다.
+
+## Apply Conditions
+
+- 실제 GitHub Branch protection 또는 저장소 변수는 변경하지 않는다.
+- audit report는 확인된 PR 상태만 기록한다.
+
+## Verification
+
+- `npm run check:audit`
+- `npm run check:all`
+- `GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/pr-automation-audit PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "capture:local": "node scripts/capture-local-screenshot.mjs",
     "check:automerge": "node scripts/check-automerge-readiness.mjs",
     "check:governance": "node scripts/check-governance.mjs",
-    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:governance && npm run build"
+    "check:audit": "node scripts/check-audit-reports.mjs",
+    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:governance && npm run check:audit && npm run build"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/reports/audits/pr_automation_20260427.md
+++ b/reports/audits/pr_automation_20260427.md
@@ -1,0 +1,39 @@
+# PR Automation Audit - 2026-04-27
+
+Status: pass
+
+## 범위
+
+PR 단위 자동 체크와 GitHub native auto-merge trial이 실제 저장소에서 반복 가능하게 동작했는지 확인했다.
+
+## 결과 요약
+
+| PR | 제목 | Head branch | 상태 | 증거 |
+| --- | --- | --- | --- | --- |
+| PR #1 | 자율 보고와 감사 포맷 추가 | `codex/autonomous-report-formats` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #2 | 자율 적용 조건과 대시보드 추가 | `codex/apply-dashboard-scaffold` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #3 | 대시보드 자동 갱신 추가 | `codex/dashboard-auto-update` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #4 | 브라우저 오프라인과 반응형 QA 완료 | `codex/browser-offline-desktop-qa` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #5 | 자동 머지 운영 거버넌스 추가 | `codex/automerge-governance` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+
+## 확인한 조건
+
+- 모든 PR은 base branch가 `main`이었다.
+- 모든 PR은 `codex/` branch prefix를 사용했다.
+- 모든 PR은 `agent-automerge` label을 사용했다.
+- 모든 PR에서 `Verify game baseline` check가 통과했다.
+- 모든 PR에서 `Check automerge eligibility` check가 통과했다.
+- 모든 PR은 GitHub native auto-merge 요청 이후 squash merge로 `main`에 반영됐다.
+- 각 merge 이후 `main` push CI가 성공했다.
+
+## 남은 위험
+
+- Branch protection과 `ENABLE_AGENT_AUTOMERGE` 저장소 변수는 아직 실제 GitHub 설정으로 고정하지 않았다.
+- PR 결과 audit은 현재 수동 작성이며, GitHub API에서 자동 생성하지 않는다.
+- auto-merge 실패 케이스는 아직 별도 PR로 검증하지 않았다.
+
+## 다음 조치
+
+- GitHub Branch protection 설정 여부를 audit한다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜기 전 실패 케이스 PR 또는 dry-run 절차를 추가한다.
+- PR 결과 audit을 `gh` 조회 기반으로 생성하는 스크립트를 추가한다.

--- a/scripts/check-apply-conditions.mjs
+++ b/scripts/check-apply-conditions.mjs
@@ -10,7 +10,9 @@ const requiredPaths = [
   "items/0002-dashboard-auto-update.md",
   "items/0003-browser-offline-desktop-qa.md",
   "items/0004-automerge-governance.md",
+  "items/0005-pr-automation-audit.md",
   "reports/audits/audit_20260427.md",
+  "reports/audits/pr_automation_20260427.md",
   "reports/reviews/README.md"
 ];
 

--- a/scripts/check-audit-reports.mjs
+++ b/scripts/check-audit-reports.mjs
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+
+const requiredPaths = [
+  "reports/audits/audit_20260427.md",
+  "reports/audits/pr_automation_20260427.md",
+  "items/0005-pr-automation-audit.md"
+];
+
+const requiredPhrases = new Map([
+  [
+    "reports/audits/pr_automation_20260427.md",
+    ["PR #1", "PR #2", "PR #3", "PR #4", "PR #5", "MERGED", "Agent Automerge Trial", "main CI"]
+  ],
+  ["items/0005-pr-automation-audit.md", ["Status: verified", "PR 자동화 결과", "npm run check:audit"]]
+]);
+
+const failures = [];
+
+for (const path of requiredPaths) {
+  if (!fs.existsSync(path)) {
+    failures.push(`missing required path: ${path}`);
+  }
+}
+
+for (const [path, phrases] of requiredPhrases.entries()) {
+  if (!fs.existsSync(path)) {
+    continue;
+  }
+
+  const content = fs.readFileSync(path, "utf8");
+  for (const phrase of phrases) {
+    if (!content.includes(phrase)) {
+      failures.push(`${path} missing phrase: ${phrase}`);
+    }
+  }
+}
+
+console.log(JSON.stringify({ ok: failures.length === 0, requiredPaths: requiredPaths.length, failures }, null, 2));
+
+if (failures.length > 0) {
+  process.exit(1);
+}

--- a/scripts/check-docs-index.mjs
+++ b/scripts/check-docs-index.mjs
@@ -38,7 +38,7 @@ for (const dir of requiredDirs) {
   }
 }
 
-for (const phrase of ["Milestone 5", "review report", "audit report", "dashboard"]) {
+for (const phrase of ["Milestone 5", "review report", "audit report", "dashboard", "PR automation audit"]) {
   if (!roadmap.includes(phrase)) {
     failures.push(`docs/ROADMAP.md missing phrase: ${phrase}`);
   }

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -34,7 +34,8 @@ const rows = [
   ["PR 자동 검증", fileStatus([".github/workflows/ci.yml", ".github/workflows/agent-automerge.yml"]), "PR #1, PR #2"],
   ["Apply gate", fileStatus(["docs/APPLY_CONDITIONS.md", "scripts/check-apply-conditions.mjs"]), "`npm run check:apply`"],
   ["대시보드 자동 갱신", stepStatus("Create dashboard", "review"), "`npm run update:dashboard`, `npm run check:dashboard`"],
-  ["자동 머지 거버넌스", stepStatus("Document automerge governance", "review"), "`npm run check:governance`"]
+  ["자동 머지 거버넌스", stepStatus("Document automerge governance", "review"), "`npm run check:governance`"],
+  ["PR 자동화 audit", stepStatus("Accumulate PR automation audit", "review"), "`npm run check:audit`"]
 ];
 
 const commands = [
@@ -45,6 +46,7 @@ const commands = [
   "npm run check:apply",
   "npm run check:dashboard",
   "npm run check:governance",
+  "npm run check:audit",
   "npm run build"
 ];
 
@@ -72,8 +74,8 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 
 ## 다음 작업
 
-1. PR 자동화 결과를 audit report에 누적한다.
-2. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
+1. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
+2. PR 결과 audit을 \`gh\` 조회 기반으로 생성하는 스크립트를 추가한다.
 3. 다음 게임 기능 작업을 \`items/\` 단위로 등록한다.
 
 ## 검증 상태


### PR DESCRIPTION
## 목적

PR #1부터 PR #5까지 반복한 자동 체크와 auto-merge trial 결과를 audit report로 고정합니다.

## 변경

- PR 자동화 결과 audit report 추가
- audit report 점검 스크립트 추가
- check:all에 check:audit 포함
- dashboard, roadmap, reporting, item 기록 갱신

## 검증

- gh pr list --repo bborok1234/strange-seed-shop --state all --limit 10
- npm run check:audit
- npm run check:all
- GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/pr-automation-audit PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge

## 자동화 실험 조건

- branch: codex/pr-automation-audit
- label: agent-automerge
- base: main
- fork: false

실제 Branch protection 또는 ENABLE_AGENT_AUTOMERGE 설정은 이 PR에서 변경하지 않습니다.