### PR TITLE
Branch protection 상태 audit

### DIFF
--- a/docs/AUTOMERGE_GOVERNANCE.md
+++ b/docs/AUTOMERGE_GOVERNANCE.md
@@ -10,6 +10,8 @@
 
 `Agent Automerge Trial` workflow는 PR이 자동 머지 후보인지 판정하고 전체 검증을 실행한다. 실제 GitHub native auto-merge 요청은 저장소 변수 `ENABLE_AGENT_AUTOMERGE`가 `true`일 때만 실행된다.
 
+2026-04-27 audit 기준으로 `main`은 `protected: false`이며, private repository의 Branch protection endpoint는 `HTTP 403`을 반환했다. 따라서 `ENABLE_AGENT_AUTOMERGE`는 계속 꺼진 상태를 유지한다.
+
 ## Branch protection
 
 `main`에는 아래 required checks를 요구하는 Branch protection을 권장한다.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -17,20 +17,21 @@ Updated: 2026-04-27
 | 대시보드 자동 갱신 | review | `npm run update:dashboard`, `npm run check:dashboard` |
 | 자동 머지 거버넌스 | review | `npm run check:governance` |
 | PR 자동화 audit | review | `npm run check:audit` |
+| Branch protection audit | review | `reports/audits/branch_protection_20260427.md` |
 
 ## 로드맵 요약
 
 | 상태 | 개수 |
 | --- | ---: |
 | done | 24 |
-| review | 7 |
+| review | 8 |
 | todo | 0 |
 | blocked | 0 |
 
 ## 다음 작업
 
-1. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
-2. PR 결과 audit을 `gh` 조회 기반으로 생성하는 스크립트를 추가한다.
+1. PR 결과 audit을 `gh` 조회 기반으로 생성하는 스크립트를 추가한다.
+2. Branch protection 사용 가능 조건이 바뀌면 required checks 설정을 별도 승인으로 진행한다.
 3. 다음 게임 기능 작업을 `items/` 단위로 등록한다.
 
 ## 검증 상태
@@ -49,6 +50,6 @@ Updated: 2026-04-27
 
 ## 열린 위험
 
-- `ENABLE_AGENT_AUTOMERGE` 저장소 변수와 Branch protection은 문서화됐지만 실제 GitHub 설정 변경은 별도 승인 대상이다.
+- `main` Branch protection은 현재 비활성이고 private repo 제한으로 endpoint가 HTTP 403을 반환했다. `ENABLE_AGENT_AUTOMERGE`는 계속 비활성 상태로 유지한다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -84,6 +84,7 @@ Goal: make the project increasingly self-managing.
 | Create dashboard | review | `docs/DASHBOARD.md`, `scripts/update-dashboard.mjs` | Current status, next item, verification health visible and checkable |
 | Document automerge governance | review | `docs/AUTOMERGE_GOVERNANCE.md`, `scripts/check-governance.mjs` | Branch protection, required checks, and `ENABLE_AGENT_AUTOMERGE` operating rules are checkable |
 | Accumulate PR automation audit | review | `reports/audits/pr_automation_20260427.md`, `scripts/check-audit-reports.mjs` | PR #1-#5 automation results are preserved and checkable |
+| Audit Branch protection status | review | `reports/audits/branch_protection_20260427.md` | `main.protected=false` and Branch protection access limit are recorded |
 
 ## Current Next Action
 
@@ -91,4 +92,4 @@ Browser Use 기반 스크린샷 자동화, 핵심 클릭 플로우, 오프라인
 
 1. 이 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
 2. 자동 머지 trial을 통해 main에 반영한다.
-3. 다음 자동화 항목으로 GitHub Branch protection 설정 여부를 audit한다.
+3. 다음 자동화 항목으로 PR 결과 audit 자동 생성 스크립트를 추가한다.

--- a/items/0006-branch-protection-audit.md
+++ b/items/0006-branch-protection-audit.md
@@ -1,0 +1,43 @@
+# GitHub Branch protection 설정 audit
+
+Status: verified
+Owner: agent
+Created: 2026-04-27
+Updated: 2026-04-27
+Scope-risk: narrow
+
+## Intent
+
+자동 머지 trial을 실제 무인 운영으로 확대하기 전에 `main` branch가 required checks를 강제하는지 확인하고, 현재 위험을 audit report로 남긴다.
+
+## Acceptance Criteria
+
+- `main` branch의 protected 상태를 GitHub API로 확인한다.
+- Branch protection endpoint 결과 또는 제한 사유를 기록한다.
+- `ENABLE_AGENT_AUTOMERGE` 활성화 가능 여부를 판단한다.
+- audit report가 `npm run check:audit`에 포함된다.
+
+## Evidence
+
+- `reports/audits/branch_protection_20260427.md`
+- 2026-04-27: `main.protected=false` 확인
+- 2026-04-27: protection endpoint가 `HTTP 403` 반환
+- 2026-04-27: `npm run check:audit` 통과
+
+## Proposed Plan
+
+- GitHub API로 branch 상태를 조회한다.
+- 조회 결과를 audit report로 남긴다.
+- audit check에 필수 문구를 추가한다.
+- 대시보드와 로드맵의 다음 작업을 갱신한다.
+
+## Apply Conditions
+
+- 이 작업에서는 GitHub 설정을 변경하지 않는다.
+- Branch protection 또는 저장소 변수 변경은 별도 승인과 별도 audit이 필요하다.
+
+## Verification
+
+- `npm run check:audit`
+- `npm run check:all`
+- `GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/branch-protection-audit PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge`

--- a/reports/audits/branch_protection_20260427.md
+++ b/reports/audits/branch_protection_20260427.md
@@ -1,0 +1,58 @@
+# Branch Protection Audit - 2026-04-27
+
+Status: warn
+
+## 범위
+
+GitHub `main` branch의 Branch protection 상태를 조회해, `ENABLE_AGENT_AUTOMERGE` 활성화 전제 조건이 충족되어 있는지 확인했다.
+
+## 조회 결과
+
+명령:
+
+```bash
+gh api repos/bborok1234/strange-seed-shop/branches/main --jq '{name: .name, protected: .protected, protection_url: .protection_url}'
+```
+
+결과:
+
+```json
+{
+  "name": "main",
+  "protected": false,
+  "protection_url": "https://api.github.com/repos/bborok1234/strange-seed-shop/branches/main/protection"
+}
+```
+
+보호 설정 endpoint 조회:
+
+```bash
+gh api repos/bborok1234/strange-seed-shop/branches/main/protection --silent
+```
+
+결과:
+
+```text
+HTTP 403: Upgrade to GitHub Pro or make this repository public to enable this feature.
+```
+
+## 판단
+
+- `main`은 현재 `protected: false`다.
+- required checks는 GitHub Branch protection으로 강제되지 않는다.
+- private repository에서 Branch protection 기능 접근이 현재 제한되어 있다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜면 Branch protection 없이 auto-merge 요청이 즉시 병합에 가까운 동작을 할 수 있다.
+
+## required checks 목표
+
+`ENABLE_AGENT_AUTOMERGE`를 켜기 전 아래 required checks가 강제되어야 한다.
+
+- `Verify game baseline`
+- `Check automerge eligibility`
+
+## 다음 조치
+
+- GitHub 플랜 또는 repository 공개 여부를 결정한다.
+- Branch protection을 사용할 수 있게 된 뒤 `main`에 required checks를 설정한다.
+- 설정 후 이 audit report를 `pass`로 갱신한다.
+- 그 전까지 `ENABLE_AGENT_AUTOMERGE`는 꺼진 상태를 유지한다.

--- a/scripts/check-audit-reports.mjs
+++ b/scripts/check-audit-reports.mjs
@@ -3,13 +3,19 @@ import fs from "node:fs";
 const requiredPaths = [
   "reports/audits/audit_20260427.md",
   "reports/audits/pr_automation_20260427.md",
-  "items/0005-pr-automation-audit.md"
+  "reports/audits/branch_protection_20260427.md",
+  "items/0005-pr-automation-audit.md",
+  "items/0006-branch-protection-audit.md"
 ];
 
 const requiredPhrases = new Map([
   [
     "reports/audits/pr_automation_20260427.md",
     ["PR #1", "PR #2", "PR #3", "PR #4", "PR #5", "MERGED", "Agent Automerge Trial", "main CI"]
+  ],
+  [
+    "reports/audits/branch_protection_20260427.md",
+    ["protected: false", "HTTP 403", "ENABLE_AGENT_AUTOMERGE", "required checks", "warn"]
   ],
   ["items/0005-pr-automation-audit.md", ["Status: verified", "PR 자동화 결과", "npm run check:audit"]]
 ]);

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -35,7 +35,8 @@ const rows = [
   ["Apply gate", fileStatus(["docs/APPLY_CONDITIONS.md", "scripts/check-apply-conditions.mjs"]), "`npm run check:apply`"],
   ["대시보드 자동 갱신", stepStatus("Create dashboard", "review"), "`npm run update:dashboard`, `npm run check:dashboard`"],
   ["자동 머지 거버넌스", stepStatus("Document automerge governance", "review"), "`npm run check:governance`"],
-  ["PR 자동화 audit", stepStatus("Accumulate PR automation audit", "review"), "`npm run check:audit`"]
+  ["PR 자동화 audit", stepStatus("Accumulate PR automation audit", "review"), "`npm run check:audit`"],
+  ["Branch protection audit", stepStatus("Audit Branch protection status", "review"), "`reports/audits/branch_protection_20260427.md`"]
 ];
 
 const commands = [
@@ -74,8 +75,8 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 
 ## 다음 작업
 
-1. GitHub Branch protection 설정 여부를 별도 audit로 확인한다.
-2. PR 결과 audit을 \`gh\` 조회 기반으로 생성하는 스크립트를 추가한다.
+1. PR 결과 audit을 \`gh\` 조회 기반으로 생성하는 스크립트를 추가한다.
+2. Branch protection 사용 가능 조건이 바뀌면 required checks 설정을 별도 승인으로 진행한다.
 3. 다음 게임 기능 작업을 \`items/\` 단위로 등록한다.
 
 ## 검증 상태
@@ -86,7 +87,7 @@ ${commands.map((command) => `| \`${command}\` | tracked |`).join("\n")}
 
 ## 열린 위험
 
-- \`ENABLE_AGENT_AUTOMERGE\` 저장소 변수와 Branch protection은 문서화됐지만 실제 GitHub 설정 변경은 별도 승인 대상이다.
+- \`main\` Branch protection은 현재 비활성이고 private repo 제한으로 endpoint가 HTTP 403을 반환했다. \`ENABLE_AGENT_AUTOMERGE\`는 계속 비활성 상태로 유지한다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.
 `;


### PR DESCRIPTION
## 목적

자동 머지 활성화 전제 조건인 main Branch protection 상태를 GitHub API로 확인하고 audit report로 남깁니다.

## 조회 결과

- main protected: false
- protection endpoint: HTTP 403
- 결론: ENABLE_AGENT_AUTOMERGE는 계속 비활성 유지

## 변경

- Branch protection audit report 추가
- audit check에 branch protection report 포함
- automerge governance, dashboard, roadmap 갱신

## 검증

- gh api repos/bborok1234/strange-seed-shop/branches/main --jq '{name: .name, protected: .protected, protection_url: .protection_url}'
- gh api repos/bborok1234/strange-seed-shop/branches/main/protection --silent returned HTTP 403
- npm run check:audit
- npm run check:all
- GITHUB_EVENT_NAME=pull_request PR_HEAD_REF=codex/branch-protection-audit PR_BASE_REF=main PR_IS_FORK=false PR_LABELS=agent-automerge npm run check:automerge

## 자동화 실험 조건

- branch: codex/branch-protection-audit
- label: agent-automerge
- base: main
- fork: false