### PR TITLE
PR audit를 9번째 자동화 PR까지 갱신

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,13 +85,13 @@ Goal: make the project increasingly self-managing.
 | Document automerge governance | review | `docs/AUTOMERGE_GOVERNANCE.md`, `scripts/check-governance.mjs` | Branch protection, required checks, and `ENABLE_AGENT_AUTOMERGE` operating rules are checkable |
 | Accumulate PR automation audit | review | `reports/audits/pr_automation_20260427.md`, `scripts/check-audit-reports.mjs` | PR #1-#5 automation results are preserved and checkable |
 | Audit Branch protection status | review | `reports/audits/branch_protection_20260427.md` | `main.protected=false` and Branch protection access limit are recorded |
-| Generate PR automation audit | review | `scripts/update-pr-automation-audit.mjs`, `reports/audits/pr_automation_20260427.md` | PR automation audit can be regenerated from `gh pr list` |
+| Generate PR automation audit | review | `scripts/update-pr-automation-audit.mjs`, `reports/audits/pr_automation_20260427.md` | PR automation audit can be regenerated from `gh pr list`; PR #1-#9 are recorded |
 | Browser Use QA gate | review | `scripts/check-browser-qa.mjs`, `reports/visual/browser-use-main-20260427.png` | Browser Use first policy and visual evidence are checked by `npm run check:browser-qa` |
 
 ## Current Next Action
 
 Browser Use 기반 스크린샷 자동화, 핵심 클릭 플로우, 오프라인 복귀, 모바일/데스크톱 캡처가 확인됐다.
 
-1. Browser Use QA gate 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
+1. PR #8/#9 audit refresh 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
 2. 자동 머지 trial을 통해 main에 반영한다.
 3. 다음 게임 기능 작업을 `items/` 단위로 등록한다.

--- a/items/0009-pr-audit-refresh-9.md
+++ b/items/0009-pr-audit-refresh-9.md
@@ -1,0 +1,29 @@
+# PR audit refresh through PR #9
+
+Status: verified
+
+## 목적
+
+PR #8과 PR #9가 merge된 뒤 PR 자동화 audit 문서를 최신 상태로 갱신한다.
+
+## 범위
+
+- `reports/audits/pr_automation_20260427.md`
+- `scripts/check-audit-reports.mjs`
+- `docs/ROADMAP.md`
+
+## 완료 조건
+
+- `npm run update:pr-audit`가 `gh pr list` 기준으로 PR #1-#9를 기록한다.
+- `npm run check:audit`가 PR #8, PR #9, 자동화 PR 수 9개를 요구한다.
+- `npm run check:all`이 통과한다.
+
+## 검증
+
+- `npm run update:pr-audit`
+- `npm run check:audit`
+- `npm run check:all`
+
+## 비고
+
+이 항목은 PR audit 생성기가 실제 신규 PR 결과를 추적하는지 확인하기 위한 짧은 회귀 검증이다.

--- a/reports/audits/pr_automation_20260427.md
+++ b/reports/audits/pr_automation_20260427.md
@@ -19,11 +19,13 @@ PR 단위 자동 체크와 GitHub native auto-merge trial이 실제 저장소에
 | PR #5 | 자동 머지 운영 거버넌스 추가 | `codex/automerge-governance` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
 | PR #6 | PR 자동화 결과 audit 누적 | `codex/pr-automation-audit` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
 | PR #7 | Branch protection 상태 audit | `codex/branch-protection-audit` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #8 | PR audit 생성을 gh 조회로 자동화 | `codex/generated-pr-audit` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
+| PR #9 | Browser Use QA를 자동 검증 루프에 고정 | `codex/browser-use-qa-gate` | MERGED | CI pass, Agent Automerge Trial pass, main CI pass |
 
 ## 확인한 조건
 
-- 자동화 PR 수: 7
-- 병합된 자동화 PR 수: 7
+- 자동화 PR 수: 9
+- 병합된 자동화 PR 수: 9
 - 모든 자동화 PR은 base branch가 `main`이었다: yes
 - 모든 자동화 PR은 `codex/` 또는 `agent/` branch prefix를 사용했다: yes
 - 모든 병합 PR은 `agent-automerge` label을 사용해 Agent Automerge Trial workflow를 통과한 PR이다.

--- a/scripts/check-apply-conditions.mjs
+++ b/scripts/check-apply-conditions.mjs
@@ -14,6 +14,7 @@ const requiredPaths = [
   "items/0006-branch-protection-audit.md",
   "items/0007-generated-pr-audit.md",
   "items/0008-browser-use-qa-gate.md",
+  "items/0009-pr-audit-refresh-9.md",
   "reports/audits/audit_20260427.md",
   "reports/audits/pr_automation_20260427.md",
   "reports/reviews/README.md"

--- a/scripts/check-audit-reports.mjs
+++ b/scripts/check-audit-reports.mjs
@@ -7,6 +7,7 @@ const requiredPaths = [
   "items/0005-pr-automation-audit.md",
   "items/0006-branch-protection-audit.md",
   "items/0007-generated-pr-audit.md",
+  "items/0009-pr-audit-refresh-9.md",
   "scripts/update-pr-automation-audit.mjs"
 ];
 
@@ -22,6 +23,10 @@ const requiredPhrases = new Map([
       "PR #5",
       "PR #6",
       "PR #7",
+      "PR #8",
+      "PR #9",
+      "자동화 PR 수: 9",
+      "병합된 자동화 PR 수: 9",
       "MERGED",
       "Agent Automerge Trial",
       "main CI"
@@ -32,7 +37,8 @@ const requiredPhrases = new Map([
     ["protected: false", "HTTP 403", "ENABLE_AGENT_AUTOMERGE", "required checks", "warn"]
   ],
   ["items/0005-pr-automation-audit.md", ["Status: verified", "PR 자동화 결과", "npm run check:audit"]],
-  ["items/0007-generated-pr-audit.md", ["Status: verified", "PR 결과 audit 자동 생성", "npm run update:pr-audit"]]
+  ["items/0007-generated-pr-audit.md", ["Status: verified", "PR 결과 audit 자동 생성", "npm run update:pr-audit"]],
+  ["items/0009-pr-audit-refresh-9.md", ["Status: verified", "PR #9", "npm run update:pr-audit"]]
 ]);
 
 const failures = [];


### PR DESCRIPTION
## 요약
- gh pr list 기반 PR automation audit를 PR #1-#9까지 갱신했습니다.
- check:audit가 PR #8, PR #9, 자동화 PR 수 9개를 요구하도록 강화했습니다.
- item 0009로 audit refresh 회귀 작업을 기록했습니다.

## 검증
- npm run update:pr-audit
- npm run check:audit
- npm run check:all

## 운영 메모
- 이후 자동화 PR이 merge되면 update:pr-audit와 check:audit 기대값 갱신을 함께 수행해야 합니다.