### PR TITLE
PR audit의 자기 갱신 루프를 차단

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -85,13 +85,13 @@ Goal: make the project increasingly self-managing.
 | Document automerge governance | review | `docs/AUTOMERGE_GOVERNANCE.md`, `scripts/check-governance.mjs` | Branch protection, required checks, and `ENABLE_AGENT_AUTOMERGE` operating rules are checkable |
 | Accumulate PR automation audit | review | `reports/audits/pr_automation_20260427.md`, `scripts/check-audit-reports.mjs` | PR #1-#5 automation results are preserved and checkable |
 | Audit Branch protection status | review | `reports/audits/branch_protection_20260427.md` | `main.protected=false` and Branch protection access limit are recorded |
-| Generate PR automation audit | review | `scripts/update-pr-automation-audit.mjs`, `reports/audits/pr_automation_20260427.md` | PR automation audit can be regenerated from `gh pr list`; PR #1-#9 are recorded |
+| Generate PR automation audit | review | `scripts/update-pr-automation-audit.mjs`, `reports/audits/pr_automation_20260427.md` | PR automation audit can be regenerated from `gh pr list`; `check:audit` validates snapshot consistency instead of forcing endless self-refresh |
 | Browser Use QA gate | review | `scripts/check-browser-qa.mjs`, `reports/visual/browser-use-main-20260427.png` | Browser Use first policy and visual evidence are checked by `npm run check:browser-qa` |
 
 ## Current Next Action
 
 Browser Use 기반 스크린샷 자동화, 핵심 클릭 플로우, 오프라인 복귀, 모바일/데스크톱 캡처가 확인됐다.
 
-1. PR #8/#9 audit refresh 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
+1. PR audit snapshot gate 브랜치를 PR로 올려 GitHub Actions의 PR 이벤트 검증을 확인한다.
 2. 자동 머지 trial을 통해 main에 반영한다.
 3. 다음 게임 기능 작업을 `items/` 단위로 등록한다.

--- a/items/0010-pr-audit-snapshot-gate.md
+++ b/items/0010-pr-audit-snapshot-gate.md
@@ -1,0 +1,29 @@
+# PR audit snapshot gate
+
+Status: verified
+
+## 목적
+
+PR audit를 갱신하는 PR이 자기 자신을 다시 audit해야 하는 무한 갱신 루프를 방지한다.
+
+## 범위
+
+- `scripts/check-audit-reports.mjs`
+- `scripts/update-pr-automation-audit.mjs`
+- `reports/audits/pr_automation_20260427.md`
+- `docs/ROADMAP.md`
+
+## 완료 조건
+
+- PR audit report가 생성 시점의 스냅샷임을 명시한다.
+- `check:audit`가 고정된 PR 총수를 요구하지 않고 report 내부의 행 수와 카운트 일치 여부를 검증한다.
+- audit 갱신 PR 자체를 다시 audit해야 하는 루프를 만들지 않는다.
+
+## 검증
+
+- `npm run check:audit`
+- `npm run check:all`
+
+## 비고
+
+신규 기능 PR 또는 운영상 중요한 PR 묶음을 audit에 반영해야 할 때만 `npm run update:pr-audit`를 실행한다.

--- a/reports/audits/pr_automation_20260427.md
+++ b/reports/audits/pr_automation_20260427.md
@@ -7,6 +7,7 @@ Status: pass
 PR 단위 자동 체크와 GitHub native auto-merge trial이 실제 저장소에서 반복 가능하게 동작했는지 확인했다.
 
 이 파일은 `npm run update:pr-audit`로 갱신한다.
+이 report는 생성 시점의 스냅샷이다. audit 갱신 PR 자체는 다음 스냅샷에 반드시 포함하지 않아도 되며, `check:audit`는 고정 PR 번호가 아니라 report 내부 일관성을 검증한다.
 
 ## 결과 요약
 
@@ -37,6 +38,7 @@ PR 단위 자동 체크와 GitHub native auto-merge trial이 실제 저장소에
 
 - Branch protection과 `ENABLE_AGENT_AUTOMERGE` 저장소 변수는 아직 실제 GitHub 설정으로 고정하지 않았다.
 - 이 report는 `gh pr list`에서 얻은 PR 상태를 기준으로 생성하며, 개별 check URL은 별도 `gh run list` 증거로 확인한다.
+- audit 갱신 PR이 자기 자신을 다시 audit해야 하는 무한 갱신 루프는 만들지 않는다.
 - auto-merge 실패 케이스는 아직 별도 PR로 검증하지 않았다.
 
 ## 다음 조치

--- a/scripts/check-apply-conditions.mjs
+++ b/scripts/check-apply-conditions.mjs
@@ -15,6 +15,7 @@ const requiredPaths = [
   "items/0007-generated-pr-audit.md",
   "items/0008-browser-use-qa-gate.md",
   "items/0009-pr-audit-refresh-9.md",
+  "items/0010-pr-audit-snapshot-gate.md",
   "reports/audits/audit_20260427.md",
   "reports/audits/pr_automation_20260427.md",
   "reports/reviews/README.md"

--- a/scripts/check-audit-reports.mjs
+++ b/scripts/check-audit-reports.mjs
@@ -25,8 +25,9 @@ const requiredPhrases = new Map([
       "PR #7",
       "PR #8",
       "PR #9",
-      "자동화 PR 수: 9",
-      "병합된 자동화 PR 수: 9",
+      "이 report는 생성 시점의 스냅샷",
+      "고정 PR 번호가 아니라 report 내부 일관성을 검증",
+      "무한 갱신 루프는 만들지 않는다",
       "MERGED",
       "Agent Automerge Trial",
       "main CI"
@@ -59,6 +60,27 @@ for (const [path, phrases] of requiredPhrases.entries()) {
     if (!content.includes(phrase)) {
       failures.push(`${path} missing phrase: ${phrase}`);
     }
+  }
+}
+
+const prAuditPath = "reports/audits/pr_automation_20260427.md";
+if (fs.existsSync(prAuditPath)) {
+  const content = fs.readFileSync(prAuditPath, "utf8");
+  const prRows = content.match(/^\| PR #\d+ \|/gm) ?? [];
+  const totalMatch = content.match(/- 자동화 PR 수: (\d+)/);
+  const mergedMatch = content.match(/- 병합된 자동화 PR 수: (\d+)/);
+  const mergedRows = content.match(/^\| PR #\d+ \|.*\| MERGED \|/gm) ?? [];
+
+  if (!totalMatch) {
+    failures.push(`${prAuditPath} missing automation PR count`);
+  } else if (Number(totalMatch[1]) !== prRows.length) {
+    failures.push(`${prAuditPath} automation PR count mismatch: ${totalMatch[1]} != ${prRows.length}`);
+  }
+
+  if (!mergedMatch) {
+    failures.push(`${prAuditPath} missing merged automation PR count`);
+  } else if (Number(mergedMatch[1]) !== mergedRows.length) {
+    failures.push(`${prAuditPath} merged automation PR count mismatch: ${mergedMatch[1]} != ${mergedRows.length}`);
   }
 }
 

--- a/scripts/update-pr-automation-audit.mjs
+++ b/scripts/update-pr-automation-audit.mjs
@@ -45,6 +45,7 @@ Status: ${allMainBase && allAgentPrefix && allMerged ? "pass" : "warn"}
 PR 단위 자동 체크와 GitHub native auto-merge trial이 실제 저장소에서 반복 가능하게 동작했는지 확인했다.
 
 이 파일은 \`npm run update:pr-audit\`로 갱신한다.
+이 report는 생성 시점의 스냅샷이다. audit 갱신 PR 자체는 다음 스냅샷에 반드시 포함하지 않아도 되며, \`check:audit\`는 고정 PR 번호가 아니라 report 내부 일관성을 검증한다.
 
 ## 결과 요약
 
@@ -67,6 +68,7 @@ ${rows.join("\n")}
 
 - Branch protection과 \`ENABLE_AGENT_AUTOMERGE\` 저장소 변수는 아직 실제 GitHub 설정으로 고정하지 않았다.
 - 이 report는 \`gh pr list\`에서 얻은 PR 상태를 기준으로 생성하며, 개별 check URL은 별도 \`gh run list\` 증거로 확인한다.
+- audit 갱신 PR이 자기 자신을 다시 audit해야 하는 무한 갱신 루프는 만들지 않는다.
 - auto-merge 실패 케이스는 아직 별도 PR로 검증하지 않았다.
 
 ## 다음 조치


### PR DESCRIPTION
## 요약
- PR audit report가 생성 시점의 스냅샷임을 명시합니다.
- check:audit에서 고정 PR 총수 요구를 제거하고, report 내부 행 수와 카운트 일치 여부를 검증합니다.
- audit 갱신 PR이 자기 자신을 다시 audit해야 하는 무한 갱신 루프를 막습니다.

## 검증
- npm run check:audit
- npm run check:all

## 운영 메모
- 이후 PR audit는 의미 있는 PR 묶음이 생겼을 때만 update:pr-audit로 갱신합니다.