### PR TITLE
Agent Ops: 2시간 운영 trial 증거 보고서

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -35,8 +35,8 @@ Updated: 2026-04-28
 | 상태 | 개수 |
 | --- | ---: |
 | done | 28 |
-| review | 41 |
-| todo | 6 |
+| review | 42 |
+| todo | 5 |
 | blocked | 0 |
 
 ## 다음 작업

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,7 +163,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Add iteration budget and stop rules | review | `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, `reports/operations/operator-trial-template-20260428.md` | Time, branch, risk, and network/credential stop conditions are explicit before long-running trials |
 | Create supervised trial dry-run | review | `scripts/operator-trial-dry-run.mjs`, `reports/operations/operator-trial-dry-run-20260428.md` | Trial lifecycle report is generated from fixtures without real 2h/4h/24h execution |
 | Add 2h supervised trial readiness gate | review | `reports/operations/operator-trial-readiness-20260428.md`, `scripts/check-operator-trial-readiness.mjs` | Time, token/context, branch, network, credential, heartbeat, CI, and automerge stop rules are checked before any real 2h run |
-| Run 2-hour supervised trial | todo | `reports/operations/operator-trial-*.md` | Heartbeat coverage, work completed, failures, CI status, and recovery attempts are recorded |
+| Run 2-hour supervised trial | review | `reports/operations/operator-trial-20260428T025400Z.md`, `items/0023-supervised-2h-operator-trial.md` | Heartbeat coverage, work completed, failures, CI status, and recovery attempts are recorded |
 | Run 4-hour supervised trial | todo | `reports/operations/operator-trial-*.md` | At least one complete issue-to-PR loop or an honest blocker report exists; no red PR is called complete |
 
 ## Milestone 8: Feedback + GTM Mock Intake
@@ -190,14 +190,14 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 현재 운영사 쪽은 Issue #33의 supervised 2h trial을 heartbeat/watchdog 증거와 함께 실행 중이며, asset pipeline 쪽은 Issue #22로 Codex output export와 96x96 strip normalization 경로를 문서/검증 gate로 고정한다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 현재 운영사 쪽은 Issue #33의 supervised 2h trial을 완료했고, `reports/operations/operator-trial-20260428T025400Z.md`로 heartbeat/watchdog/PR/CI 증거를 durable report화하는 중이다. 이 report PR이 merge되면 다음 안전한 운영사 작업은 4h supervised trial 준비와 `docs/OPERATOR_RUNBOOK.md`/daily operating report 템플릿이다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.
 3. Issue #46 / PR #47은 씨앗 구매/주머니 row에 `seed.creaturePool[0]`의 만날 아이 preview를 붙여 선택 전 수집 기대를 강화했다.
-4. Issue #48 / `items/0033-harvest-reveal-next-goal.md`는 첫 수확 reveal에서 다음 목표 creature/seed hint를 보여줘 “하나만 더” 루프를 강화한다.
+4. Issue #48 / PR #49는 merge 완료되어 첫 수확 reveal에서 다음 목표 creature/seed hint를 보여줘 “하나만 더” 루프를 강화한다.
 5. 첫 loop는 starter seed -> plant -> tap growth -> harvest -> named creature ownership -> album reward -> second plot/next collection goal 순서를 보존한다.
-6. Issue #25/PR #26, Issue #27/PR #28, Issue #29/PR #30, Issue #31/PR #32로 운영사 루프, watchdog, trial dry-run, readiness gate가 닫혔고, 현재 후속 작업은 Issue #33의 실제 2h trial 증거를 완성하는 것이다.
+6. Issue #25/PR #26, Issue #27/PR #28, Issue #29/PR #30, Issue #31/PR #32로 운영사 루프, watchdog, trial dry-run, readiness gate가 닫혔고, Issue #33의 실제 2h trial은 24회 heartbeat와 PR #35-#49 completed work로 완료되었다.
 7. Issue #34 / PR #35는 merge 완료되어 생명체의 성격/취향/인사말을 수확 reveal·소유 카드·도감에 노출한다.
 8. Issue #36 / PR #37은 merge 완료되어 실제 고객 데이터나 외부 채널 없이 플레이테스트 신호를 severity/product axis/evidence/duplicate/fun rubric/next item으로 정규화한다.
 9. Issue #38 / PR #39는 merge 완료되어 devlog/release note/community post를 mock proposal로만 남기고, SNS/email/ads/store/community 실채널 action은 명시 승인 전 금지한다.

--- a/items/0023-supervised-2h-operator-trial.md
+++ b/items/0023-supervised-2h-operator-trial.md
@@ -1,0 +1,59 @@
+# Supervised 2h operator trial
+
+Status: in_progress
+Owner: agent
+Created: 2026-04-28
+Updated: 2026-04-28
+Scope-risk: moderate
+Work type: agent_ops
+Issue: #33
+Branch: `codex/operator-2h-trial-report`
+
+## Intent
+
+2h supervised trial을 실제 시간 경과로 실행하고, Ralph 운영사가 heartbeat, watchdog, issue-to-PR loop, CI repair/merge discipline, stop rule을 지키며 계속 전진할 수 있는지 증거로 남긴다.
+
+## Acceptance Criteria
+
+- 2h supervised trial 시작/완료 시간이 report에 기록된다.
+- Heartbeat coverage가 5분 주기 기준으로 pass 판정을 받는다.
+- Completed work에 trial 중 닫은 issue/PR 목록이 남는다.
+- Red CI를 완료로 착각하지 않고 repair 또는 blocker로 분류했다는 증거가 있다.
+- Stop rules observed 섹션이 credential, 고객 데이터, 결제, 로그인, ads SDK, 실채널 GTM, external deployment, main 자동 merge 금지를 확인한다.
+- `npm run check:operator`와 `npm run check:all`이 통과한다.
+
+## Evidence
+
+- Issue #33: https://github.com/bborok1234/strange-seed-shop/issues/33
+- Operation report: `reports/operations/operator-trial-20260428T025400Z.md`
+- Runtime heartbeat log: `.omx/logs/operator-2h-trial-20260428T025400Z.jsonl`
+- Runtime watchdog log: `.omx/logs/operator-2h-trial-watchdog-20260428T025400Z.log`
+- Runtime summary: `.omx/logs/operator-2h-trial-20260428T025400Z.summary.md`
+- Context snapshot: `.omx/context/operator-2h-trial-20260428T025400Z.md`
+- Heartbeat coverage: pass, Observed heartbeat count: 24
+- Completed loop evidence: PR #35, PR #37, PR #39, PR #40, PR #41, PR #42, PR #43, PR #45, PR #47, PR #49
+- Local check: `npm run check:operator` PASS
+- Local check: `npm run check:all` PASS
+- Architect verification: APPROVED
+- PR: pending
+
+## Proposed Plan
+
+1. Runtime `.omx` heartbeat/watchdog evidence를 durable operation report로 요약한다.
+2. Trial 중 완료된 issue/PR/CI 상태를 표로 고정한다.
+3. Stop rule 준수와 실패/복구 시도를 명시한다.
+4. `scripts/check-operator.mjs`가 report와 item 누락을 잡도록 확장한다.
+5. 로컬 검증 후 draft PR을 만들고 GitHub checks를 확인한 뒤 Issue #33을 닫는다.
+
+## Apply Conditions
+
+- 실제 고객 데이터, credential, 결제, 로그인/account, ads SDK, external deployment, 실채널 GTM을 건드리지 않는다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜지 않는다.
+- Branch protection과 required checks를 우회하지 않는다.
+- 새 dependency를 추가하지 않는다.
+
+## Verification
+
+- `npm run check:operator`
+- `npm run check:all`
+- GitHub PR checks: `Verify game baseline`, `Check automerge eligibility`

--- a/items/0023-supervised-2h-operator-trial.md
+++ b/items/0023-supervised-2h-operator-trial.md
@@ -35,7 +35,7 @@ Branch: `codex/operator-2h-trial-report`
 - Local check: `npm run check:operator` PASS
 - Local check: `npm run check:all` PASS
 - Architect verification: APPROVED
-- PR: pending
+- PR: #50 https://github.com/bborok1234/strange-seed-shop/pull/50
 
 ## Proposed Plan
 

--- a/reports/operations/README.md
+++ b/reports/operations/README.md
@@ -11,6 +11,7 @@
 | `operator-completion-gate-YYYYMMDD.md` | 작업 완료 gate report. issue, draft PR, verification, audit/follow-up 링크가 완료 선언 전에 모두 존재하는지 기록한다. |
 | `stuck-*.md` / `stuck-drill-*.md` | stuck report. `collab: Wait`, stale tmux, red CI, timeout, orphan process가 완료로 오인되지 않게 한다. |
 | `operator-trial-*.md` | Milestone 7 이후 다시간 trial report. heartbeat coverage, completed work, recovery attempts를 기록한다. |
+| `operator-trial-20260428T025400Z.md` | Issue #33의 실제 2h supervised trial report. 24회 heartbeat, PR #35-#49 completed work, CI status, Stop rules observed, Next queue를 고정한다. |
 
 ## 최소 증거 기준
 

--- a/reports/operations/operator-trial-20260428T025400Z.md
+++ b/reports/operations/operator-trial-20260428T025400Z.md
@@ -1,0 +1,88 @@
+# Supervised 2h operator trial report
+
+Status: completed
+Issue: #33
+Branch: `codex/operator-2h-trial-report`
+Started at: 2026-04-28T02:54:00Z
+Completed at: 2026-04-28T04:54:12Z
+Stop deadline epoch: 1777352040
+Runtime heartbeat log: `.omx/logs/operator-2h-trial-20260428T025400Z.jsonl`
+Runtime watchdog log: `.omx/logs/operator-2h-trial-watchdog-20260428T025400Z.log`
+Runtime summary: `.omx/logs/operator-2h-trial-20260428T025400Z.summary.md`
+Context snapshot: `.omx/context/operator-2h-trial-20260428T025400Z.md`
+Durable item: `items/0023-supervised-2h-operator-trial.md`
+
+## Executive Summary
+
+Issue #33의 2h supervised trial은 2026-04-28T02:54:00Z부터 2026-04-28T04:54:12Z까지 실행되었다. 5분 주기의 heartbeat가 24회 관측되었고, watchdog은 마지막 heartbeat까지 freshness threshold 안에서 `fresh`로 판정했다. Trial 중 10개의 issue-to-PR loop가 완료되어 main에 merge되었고, 각 PR은 `Verify game baseline`과 `Check automerge eligibility`를 통과했다. Red CI를 완료로 부르는 사례는 없었다.
+
+## Heartbeat coverage
+
+Heartbeat coverage: pass
+Observed heartbeat count: 24
+Expected heartbeat count: 24
+First heartbeat: 2026-04-28T02:54:00.510Z
+Last heartbeat: 2026-04-28T04:49:11.878Z
+Minimum observed gap: 300s
+Maximum observed gap: 301s
+Average observed gap: about 300.4s
+Watchdog final status: fresh
+
+Coverage 판단: 시작 직후 heartbeat 1회를 기록했고, 이후 deadline 직전까지 5분 간격으로 총 24회가 남았다. Watchdog tail은 2026-04-28T04:49:11Z 점검에서 마지막 heartbeat age를 0초로 기록했다.
+
+## Completed work
+
+| PR | Closed issue | Area | Merge time | Merge commit | Result |
+| --- | --- | --- | --- | --- | --- |
+| PR #35 | Issue #34 | Game: 첫 수확 생명체 애착 문구 노출 | 2026-04-28T03:09:16Z | `9f1bcc40ee5c36553028ad14431d7254875a7700` | merged, checks green |
+| PR #37 | Issue #36 | Feedback: 플레이테스트 intake와 첫 5분 fun rubric | 2026-04-28T03:19:17Z | `4f020964ddfbe7ab9626006706e0100abc1fc104` | merged, checks green |
+| PR #39 | Issue #38 | GTM: mock lane과 실채널 승인 gate | 2026-04-28T03:26:54Z | `c6c117972b439487e136cf26154d492a63aaf9c3` | merged, checks green |
+| PR #40 | Issue #21 | Sprite: state-to-animation mapping manifest binding | 2026-04-28T03:39:00Z | `cdfb62c6012ba4d2c0254fa26b404c2249b2211e` | merged, checks green |
+| PR #41 | Issue #22 | Asset: Codex output export와 strip normalization 경로 | 2026-04-28T03:47:18Z | `005fdb41e892e36fc7492f7103ae8cc88b416d6c` | merged, checks green |
+| PR #42 | Issue #17 | Agent Ops: 완료 gate를 PR 증거 조건으로 고정 | 2026-04-28T03:59:21Z | `9e17cee89567c73d78e534f975c0e4df748d6494` | merged, checks green |
+| PR #43 | Issue #18 | Browser QA: iab 직접 검증 차단과 fallback 증거 | 2026-04-28T04:07:52Z | `3841e0febd4f46f58d663af44293f3548d20e569` | merged, checks green |
+| PR #45 | Issue #44 | Game: 다음 생명체 수집 목표 카드 v0 | 2026-04-28T04:25:42Z | `8457d020de1dbc00395012065af7c9e70dee16bb` | merged, checks green |
+| PR #47 | Issue #46 | Game: 씨앗별 만날 아이 preview v0 | 2026-04-28T04:33:47Z | `409d28ae5302e8b2763dd47982d1c44860f9b273` | merged, checks green |
+| PR #49 | Issue #48 | Game: 첫 수확 reveal 다음 목표 teaser v0 | 2026-04-28T04:43:22Z | `887714e3a1dab301db62ef44e17051f9e86b19a3` | merged, checks green |
+
+## CI status
+
+- PR #35 through PR #49: `Verify game baseline` PASS, `Check automerge eligibility` PASS.
+- Main branch CI after each merge stayed green.
+- Last observed main CI run: `25034346087`, head `887714e3a1dab301db62ef44e17051f9e86b19a3`, conclusion `success`.
+- This report branch passed `npm run check:operator` and `npm run check:all` locally. The report PR must additionally pass `Verify game baseline` and `Check automerge eligibility` before closing Issue #33.
+
+## Failures and recovery attempts
+
+1. Browser Use direct `iab` runtime remained unavailable in this environment. The trial did not hide this as success: PR #43 documented the direct blockage and preserved CDP fallback evidence under `reports/visual/`.
+2. Some local screenshot capture attempts during gameplay evidence were retried after timeout; final mobile and desktop evidence files were produced before merge.
+3. Architect/review feedback on next-goal evidence required additional PR evidence; the loop updated the PR body/comments and rechecked GitHub status before merge.
+4. No red CI was called complete. Checks were watched, fixed when needed, and only green PRs were merged.
+
+## Stop rules observed
+
+Stop rules observed: pass
+
+- No credential or customer data was accessed.
+- No payment, login/account, ads SDK, runtime image generation, external deployment, or real GTM channel publishing was added.
+- `ENABLE_AGENT_AUTOMERGE` was not enabled.
+- Branch protection and required checks were not bypassed.
+- Main merges were squash merges after local checks and GitHub checks; no unsafe auto-merge was attempted.
+
+## Trial verdict
+
+The 2h supervised operator trial is accepted as a successful Milestone 7 proof: the agent maintained heartbeat/watchdog liveness, selected and completed game/operator work, generated durable issue/PR evidence, recovered from known Browser Use limitations honestly, and ended with green CI rather than false completion.
+
+## Next queue
+
+1. Open and close this report PR for Issue #33 with fresh local and GitHub checks.
+2. Promote Milestone 7 next step to a 4h supervised trial only after this report PR is merged.
+3. Before any 24h run, create `docs/OPERATOR_RUNBOOK.md` and a daily operating report template so a human can wake up to completed work, failed work, open PRs, red checks, decisions, and next queue.
+4. Keep real customer feedback, GTM publication, credentials, payment/login/ads/account work behind explicit approval gates.
+
+## Verification evidence for this report PR
+
+- Local check: `npm run check:operator` PASS
+- Local check: `npm run check:all` PASS
+- Architect verification: APPROVED
+- GitHub PR checks: pending `Verify game baseline`, pending `Check automerge eligibility`

--- a/reports/operations/operator-trial-20260428T025400Z.md
+++ b/reports/operations/operator-trial-20260428T025400Z.md
@@ -85,4 +85,4 @@ The 2h supervised operator trial is accepted as a successful Milestone 7 proof: 
 - Local check: `npm run check:operator` PASS
 - Local check: `npm run check:all` PASS
 - Architect verification: APPROVED
-- GitHub PR checks: pending for PR #50 (`Verify game baseline`, `Check automerge eligibility`)
+- GitHub PR checks: PR #50 PASS (`Verify game baseline`, `Check automerge eligibility`)

--- a/reports/operations/operator-trial-20260428T025400Z.md
+++ b/reports/operations/operator-trial-20260428T025400Z.md
@@ -85,4 +85,4 @@ The 2h supervised operator trial is accepted as a successful Milestone 7 proof: 
 - Local check: `npm run check:operator` PASS
 - Local check: `npm run check:all` PASS
 - Architect verification: APPROVED
-- GitHub PR checks: pending `Verify game baseline`, pending `Check automerge eligibility`
+- GitHub PR checks: pending for PR #50 (`Verify game baseline`, `Check automerge eligibility`)

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -39,8 +39,10 @@ const requiredPaths = [
   "items/0020-operator-watchdog-runner-trial-scaffold.md",
   "items/0021-supervised-operator-trial-dry-run.md",
   "items/0022-supervised-2h-trial-readiness-gate.md",
+  "items/0023-supervised-2h-operator-trial.md",
   "items/0029-operator-completion-gate.md",
   "reports/operations/operator-trial-readiness-20260428.md",
+  "reports/operations/operator-trial-20260428T025400Z.md",
   "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json",
   "reports/operations/operator-trial-dry-run-20260428.md",
   "scripts/write-operator-heartbeat.mjs",
@@ -165,6 +167,31 @@ requirePhrases("reports/operations/operator-trial-readiness-20260428.md", [
   "Token/context budget",
   "Credential boundary",
   "ENABLE_AGENT_AUTOMERGE"
+]);
+
+requirePhrases("items/0023-supervised-2h-operator-trial.md", [
+  "Status: in_progress",
+  "Work type: agent_ops",
+  "Issue: #33",
+  "2h supervised trial",
+  "Heartbeat coverage",
+  "Observed heartbeat count: 24",
+  "PR #49",
+  "npm run check:operator",
+  "npm run check:all"
+]);
+
+requirePhrases("reports/operations/operator-trial-20260428T025400Z.md", [
+  "Status: completed",
+  "Issue: #33",
+  "Observed heartbeat count: 24",
+  "Heartbeat coverage: pass",
+  "Completed work",
+  "PR #35",
+  "PR #49",
+  "Stop rules observed",
+  "No credential",
+  "Next queue"
 ]);
 
 requirePhrases("reports/operations/README.md", [


### PR DESCRIPTION
## 요약

- Issue #33의 실제 2h supervised operator trial을 durable report로 승격했습니다.
- 24회 heartbeat / watchdog fresh / PR #35-#49 completed work / CI green / stop rules observed를 한 report에 고정했습니다.
- `scripts/check-operator.mjs`가 새 item/report 누락을 실패로 잡도록 확장했습니다.

Closes #33

## 로컬 검증

- `npm run check:operator` PASS
- `npm run check:all` PASS
- Architect verification: APPROVED

## GitHub checks

- Verify game baseline: https://github.com/bborok1234/strange-seed-shop/actions/runs/25034945707/job/73324396164
- Check automerge eligibility: https://github.com/bborok1234/strange-seed-shop/actions/runs/25034947069/job/73324400054

## 작업 완료 gate

- Draft PR: PR #50
- Operation report: `reports/operations/operator-trial-20260428T025400Z.md`
- Work item: `items/0023-supervised-2h-operator-trial.md`
- Visual evidence: N/A — 운영 report/checker 변경이며 UI 변화 없음
- Follow-up: `docs/ROADMAP.md`의 다음 큐에 4h supervised trial, `docs/OPERATOR_RUNBOOK.md`, daily operating report 템플릿을 명시함

## 위험/제외

- `.omx` runtime log는 local evidence로 참조만 하고 commit하지 않았습니다.
- `ENABLE_AGENT_AUTOMERGE`는 켜지 않았습니다.
- credential/customer data/payment/login/ads SDK/external deployment/real GTM은 범위 밖입니다.
