### PR TITLE
Agent Ops: generate live operator trial status report

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -35,7 +35,7 @@ Updated: 2026-04-28
 | 상태 | 개수 |
 | --- | ---: |
 | done | 29 |
-| review | 47 |
+| review | 48 |
 | todo | 3 |
 | blocked | 0 |
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -168,6 +168,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Create supervised trial dry-run | review | `scripts/operator-trial-dry-run.mjs`, `reports/operations/operator-trial-dry-run-20260428.md` | Trial lifecycle report is generated from fixtures without real 2h/4h/24h execution |
 | Add 2h supervised trial readiness gate | review | `reports/operations/operator-trial-readiness-20260428.md`, `scripts/check-operator-trial-readiness.mjs` | Time, token/context, branch, network, credential, heartbeat, CI, and automerge stop rules are checked before any real 2h run |
 | Run 2-hour supervised trial | done | Issue #33, PR #50, `reports/operations/operator-trial-20260428T025400Z.md`, `items/0023-supervised-2h-operator-trial.md` | 24회 heartbeat, watchdog fresh, PR #35-#49 completed work, green CI, failures/recovery, stop rules가 기록됨 |
+| Add live operator status report | review | `scripts/update-operator-live-status.mjs`, `reports/operations/operator-live-status-20260428.md`, `items/0040-operator-live-status-report.md` | Running trial의 heartbeat freshness, deadline, completed PRs, recovery, next action을 한 파일로 생성하고 `check:operator`가 검증함 |
 | Run 4-hour supervised trial | todo | `reports/operations/operator-trial-*.md` | At least one complete issue-to-PR loop or an honest blocker report exists; no red PR is called complete |
 
 ## Milestone 8: Feedback + GTM Mock Intake
@@ -194,7 +195,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 운영사 쪽은 Issue #53의 4h supervised trial을 runtime `.omx` heartbeat/watchdog으로 실행 중이며, trial 안의 현재 제품 작업은 Issue #60의 씨앗 탭 도감 목표 강조 v0이다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 운영사 쪽은 Issue #53의 4h supervised trial을 runtime `.omx` heartbeat/watchdog으로 실행 중이며, trial 안의 현재 운영사 작업은 Issue #62의 live operator status report이다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.
@@ -216,3 +217,4 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 18. Issue #56은 도감 다음 목표 카드에서 씨앗 탭으로 이어지는 CTA를 추가해 Issue #54의 미발견 슬롯 단서를 실제 다음 행동으로 연결한다.
 19. Issue #58은 모바일 도감 첫 화면에서도 다음 발견 생명체와 씨앗 행동이 보이도록 상단 compact CTA chip을 추가한다.
 20. Issue #60은 도감 CTA 이후 씨앗 탭에서 다음 도감 목표 씨앗과 해당 row를 강조해 구매/심기 행동 전환을 돕는다.
+21. Issue #62는 장시간 운영 중 사람이 돌아왔을 때 heartbeat, deadline, 완료 PR, recovery, next action을 한 파일에서 읽을 수 있게 live status report를 생성한다.

--- a/items/0040-operator-live-status-report.md
+++ b/items/0040-operator-live-status-report.md
@@ -1,0 +1,49 @@
+# Operator live status report
+
+Status: in_progress
+Owner: agent
+Created: 2026-04-28
+Updated: 2026-04-28
+Scope-risk: narrow
+Work type: agent_ops
+Issue: #62
+Branch: `codex/operator-live-status-report`
+
+## Intent
+
+장시간 `$ralph` 운영 trial 중 사람이 중간에 돌아와도 현재 heartbeat, deadline, 완료 PR, recovery, next action을 한 파일에서 확인할 수 있게 한다.
+
+## Acceptance Criteria
+
+- `npm run operator:live-status`가 현재 runtime `.omx` env/heartbeat를 읽어 `reports/operations/operator-live-status-20260428.md`를 생성한다.
+- 보고서에는 Heartbeat freshness, heartbeat count, deadline, last heartbeat, Completed issue-to-PR loops, known recovery, next action이 있다.
+- runtime env가 없을 때도 script는 not-running/stale 상태를 보고 가능하게 설계된다.
+- `npm run check:operator`가 live status script/report/package entry를 검증한다.
+- `npm run check:all`이 통과한다.
+
+## Evidence
+
+- Issue #62: https://github.com/bborok1234/strange-seed-shop/issues/62
+- Context snapshot: `.omx/context/operator-live-status-20260428T062425Z.md`
+- Live status report: `reports/operations/operator-live-status-20260428.md`
+- Local generation: `npm run operator:live-status` PASS
+- Independent report check: `node scripts/update-operator-live-status.mjs --check --output reports/operations/operator-live-status-20260428.md` PASS
+- Local check: `npm run check:operator` PASS
+- Local check: `npm run check:all` PASS
+- Architect verification: APPROVED
+- Deslop: changed-files-only pass; report date/check mismatch fixed
+- PR: #63 https://github.com/bborok1234/strange-seed-shop/pull/63
+
+## Apply Conditions
+
+- GitHub settings, branch protection, secrets, credentials, external deployment를 변경하지 않는다.
+- 고객 데이터, 결제, 로그인/account, ads SDK, 실채널 GTM을 건드리지 않는다.
+- 실제 24h 실행을 시작하지 않는다.
+- `.omx` runtime logs는 커밋하지 않고, versioned report만 snapshot으로 남긴다.
+
+## Verification
+
+- `npm run operator:live-status`
+- `npm run check:operator`
+- `npm run check:all`
+- GitHub PR checks: `Verify game baseline`, `Check automerge eligibility`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "operator:trial:readiness": "node scripts/check-operator-trial-readiness.mjs",
     "check:playtest-intake": "node scripts/check-playtest-intake.mjs",
     "check:gtm-mock": "node scripts/check-gtm-mock.mjs",
-    "check:asset-normalization": "node scripts/check-asset-normalization.mjs"
+    "check:asset-normalization": "node scripts/check-asset-normalization.mjs",
+    "operator:live-status": "node scripts/update-operator-live-status.mjs --output reports/operations/operator-live-status-20260428.md"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/reports/operations/operator-live-status-20260428.md
+++ b/reports/operations/operator-live-status-20260428.md
@@ -1,0 +1,53 @@
+# Operator Live Status — 2026-04-28
+
+Status: fresh
+Issue: #53
+Generated at: 2026-04-28T06:30:13.990Z
+
+## Runtime source
+
+- Env file: `.omx/logs/operator-4h-trial-restart-current.env`
+- Heartbeat log: `.omx/logs/operator-4h-trial-restart-20260428T053230Z.jsonl`
+- Context snapshot: `.omx/context/operator-4h-trial-restart-20260428T053230Z.md`
+- Summary path: `.omx/logs/operator-4h-trial-restart-20260428T053230Z.summary.md`
+
+## Heartbeat freshness
+
+- Heartbeat freshness: fresh
+- Max age seconds: 600
+- Last heartbeat age seconds: 141
+- Heartbeat count: 12
+- Deadline: 2026-04-28T09:32:46.000Z
+
+## Last heartbeat
+
+- Timestamp: 2026-04-28T06:27:53.163Z
+- Phase: live-trial
+- Branch: codex/operator-live-status-report
+- Commit: dde89fa
+- Dirty: true
+- Current command: operator 4h restart heartbeat 12
+- Next action: continue until deadline 1777368766 or stop rule
+
+## Completed issue-to-PR loops
+
+- PR #55: Game: 도감 미발견 슬롯과 수집 단서 v0 (2026-04-28T05:39:04Z) — https://github.com/bborok1234/strange-seed-shop/pull/55
+- PR #57: Game: 도감 다음 목표 CTA로 씨앗 행동 연결 (2026-04-28T05:49:13Z) — https://github.com/bborok1234/strange-seed-shop/pull/57
+- PR #59: Game: expose album next action on mobile (2026-04-28T06:04:38Z) — https://github.com/bborok1234/strange-seed-shop/pull/59
+- PR #61: Game: highlight album target seed in seed tab (2026-04-28T06:21:46Z) — https://github.com/bborok1234/strange-seed-shop/pull/61
+
+## Known recovery
+
+- reports/operations/stuck-20260428-4h-trial-runner-exited.md
+- reports/operations/stuck-drill-20260428.md
+
+## Stop rules observed
+
+- Do not call red CI complete.
+- Do not use credentials, customer data, payment, login, ads SDK, external deployment, or real GTM channels.
+- Do not enable `ENABLE_AGENT_AUTOMERGE`.
+- If heartbeat is stale, write a stuck report before claiming completion.
+
+## Next action
+
+continue until deadline 1777368766 or stop rule

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -41,14 +41,17 @@ const requiredPaths = [
   "items/0022-supervised-2h-trial-readiness-gate.md",
   "items/0023-supervised-2h-operator-trial.md",
   "items/0034-operator-runbook-daily-report.md",
+  "items/0040-operator-live-status-report.md",
   "items/0029-operator-completion-gate.md",
   "docs/OPERATOR_RUNBOOK.md",
   "reports/operations/operator-trial-readiness-20260428.md",
   "reports/operations/operator-trial-20260428T025400Z.md",
   "reports/operations/daily-template-20260428.md",
+  "reports/operations/operator-live-status-20260428.md",
   "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json",
   "reports/operations/operator-trial-dry-run-20260428.md",
   "scripts/write-operator-heartbeat.mjs",
+  "scripts/update-operator-live-status.mjs",
   "scripts/operator-trial-dry-run.mjs",
   "scripts/check-operator-trial-readiness.mjs",
   "scripts/operator-watchdog.mjs",
@@ -232,6 +235,40 @@ requirePhrases("reports/operations/daily-template-20260428.md", [
   "Next queue"
 ]);
 
+requirePhrases("items/0040-operator-live-status-report.md", [
+  "Status: in_progress",
+  "Work type: agent_ops",
+  "Issue: #62",
+  "operator:live-status",
+  "Heartbeat freshness",
+  "Completed issue-to-PR loops",
+  "npm run check:operator",
+  "npm run check:all"
+]);
+
+requirePhrases("reports/operations/operator-live-status-20260428.md", [
+  "Operator Live Status",
+  "Issue: #53",
+  "Heartbeat freshness",
+  "Heartbeat count",
+  "Deadline",
+  "Last heartbeat",
+  "Completed issue-to-PR loops",
+  "PR #55",
+  "PR #61",
+  "Known recovery",
+  "Next action"
+]);
+
+requirePhrases("scripts/update-operator-live-status.mjs", [
+  "operator-live-status",
+  "Heartbeat freshness",
+  "Completed issue-to-PR loops",
+  "Known recovery",
+  "Next action",
+  "not-running"
+]);
+
 requirePhrases("reports/operations/README.md", [
   "heartbeat",
   "stuck report",
@@ -282,7 +319,15 @@ requirePhrases("docs/PR_AUTOMATION.md", [
   "red PR을 완료로 부르지 않는다"
 ]);
 
-requirePhrases("package.json", ["check:operator", "operator:watchdog", "operator:trial:dry-run", "operator:trial:readiness", "scripts/check-operator.mjs"]);
+requirePhrases("package.json", [
+  "check:operator",
+  "operator:watchdog",
+  "operator:trial:dry-run",
+  "operator:trial:readiness",
+  "operator:live-status",
+  "scripts/check-operator.mjs",
+  "scripts/update-operator-live-status.mjs"
+]);
 
 const heartbeat = readJsonLine("reports/operations/operator-heartbeat-20260428.jsonl");
 if (!heartbeat) {

--- a/scripts/update-operator-live-status.mjs
+++ b/scripts/update-operator-live-status.mjs
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (!arg.startsWith("--")) continue;
+  const key = arg.slice(2);
+  const next = process.argv[index + 1];
+  if (next && !next.startsWith("--")) {
+    args.set(key, next);
+    index += 1;
+  } else {
+    args.set(key, "true");
+  }
+}
+
+const envPath = args.get("env") ?? ".omx/logs/operator-4h-trial-restart-current.env";
+const outputPath = args.get("output") ?? `reports/operations/operator-live-status-${new Date().toISOString().slice(0, 10).replaceAll("-", "")}.md`;
+const maxAgeSeconds = Number.parseInt(args.get("max-age-seconds") ?? "600", 10);
+const checkOnly = args.get("check") === "true";
+const now = new Date();
+const reportDate = formatReportDate(outputPath, now);
+
+const snapshot = buildSnapshot({ envPath, maxAgeSeconds, now });
+const markdown = renderMarkdown(snapshot, reportDate);
+
+if (checkOnly) {
+  if (!fs.existsSync(outputPath)) {
+    console.error(JSON.stringify({ ok: false, failure: `missing live status report: ${outputPath}` }, null, 2));
+    process.exit(1);
+  }
+
+  const current = fs.readFileSync(outputPath, "utf8");
+  const requiredPhrases = [
+    "Operator Live Status",
+    "Heartbeat freshness",
+    "Heartbeat count",
+    "Deadline",
+    "Last heartbeat",
+    "Completed issue-to-PR loops",
+    "Known recovery",
+    "Next action",
+    "Issue: #53"
+  ];
+  const failures = requiredPhrases.filter((phrase) => !current.includes(phrase));
+  console.log(JSON.stringify({ ok: failures.length === 0, outputPath, failures }, null, 2));
+  if (failures.length > 0) process.exit(1);
+  process.exit(0);
+}
+
+fs.mkdirSync(outputPath.split("/").slice(0, -1).join("/"), { recursive: true });
+fs.writeFileSync(outputPath, markdown);
+console.log(JSON.stringify({ ok: true, outputPath, status: snapshot.status, heartbeatCount: snapshot.heartbeatCount }, null, 2));
+
+function buildSnapshot({ envPath, maxAgeSeconds, now }) {
+  const env = fs.existsSync(envPath) ? parseEnv(fs.readFileSync(envPath, "utf8")) : null;
+  const heartbeatPath = env?.HB_LOG;
+  const heartbeats = heartbeatPath && fs.existsSync(heartbeatPath) ? readJsonl(heartbeatPath) : [];
+  const firstHeartbeat = heartbeats.at(0) ?? null;
+  const lastHeartbeat = heartbeats.at(-1) ?? null;
+  const lastAt = lastHeartbeat?.timestamp ? new Date(lastHeartbeat.timestamp) : null;
+  const ageSeconds = lastAt ? Math.max(0, Math.round((now.getTime() - lastAt.getTime()) / 1000)) : null;
+  const fresh = ageSeconds !== null && ageSeconds <= maxAgeSeconds;
+  const deadline = env?.DEADLINE ? new Date(Number(env.DEADLINE) * 1000) : null;
+  const completedLoops = readCompletedLoops(firstHeartbeat?.timestamp ?? env?.RESTART);
+  const recoveryReports = fs.existsSync("reports/operations")
+    ? fs
+        .readdirSync("reports/operations")
+        .filter((name) => name.startsWith("stuck-") && name.endsWith(".md"))
+        .sort()
+        .map((name) => `reports/operations/${name}`)
+    : [];
+
+  return {
+    generatedAt: now.toISOString(),
+    envPath,
+    env,
+    status: env ? (fresh ? "fresh" : "stale") : "not-running",
+    maxAgeSeconds,
+    heartbeatPath: heartbeatPath ?? "n/a",
+    heartbeatCount: heartbeats.length,
+    firstHeartbeat,
+    lastHeartbeat,
+    ageSeconds,
+    deadline: deadline?.toISOString() ?? "n/a",
+    completedLoops,
+    recoveryReports,
+    nextAction: lastHeartbeat?.next_action ?? "runtime env or heartbeat missing; inspect Issue #53 and .omx logs before claiming completion"
+  };
+}
+
+function parseEnv(raw) {
+  return Object.fromEntries(
+    raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const [key, ...rest] = line.split("=");
+        return [key, rest.join("=")];
+      })
+  );
+}
+
+function readJsonl(filePath) {
+  return fs
+    .readFileSync(filePath, "utf8")
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}
+
+function readCompletedLoops(startedAt) {
+  try {
+    const raw = execFileSync(
+      "gh",
+      ["pr", "list", "--state", "merged", "--limit", "30", "--json", "number,title,mergedAt,url,headRefName"],
+      { encoding: "utf8" }
+    );
+    const started = startedAt ? Date.parse(startedAt) : 0;
+    return JSON.parse(raw)
+      .filter((pr) => Date.parse(pr.mergedAt) >= started)
+      .sort((first, second) => Date.parse(first.mergedAt) - Date.parse(second.mergedAt))
+      .map((pr) => ({
+        label: `PR #${pr.number}`,
+        title: pr.title,
+        mergedAt: pr.mergedAt,
+        url: pr.url,
+        branch: pr.headRefName
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function formatReportDate(outputPath, now) {
+  const match = outputPath.match(/operator-live-status-(\d{4})(\d{2})(\d{2})\.md$/);
+  return match ? `${match[1]}-${match[2]}-${match[3]}` : now.toISOString().slice(0, 10);
+}
+
+function renderMarkdown(snapshot, reportDate) {
+  const last = snapshot.lastHeartbeat;
+  const completed = snapshot.completedLoops.length
+    ? snapshot.completedLoops
+        .map((item) => `- ${item.label}: ${item.title} (${item.mergedAt}) — ${item.url}`)
+        .join("\n")
+    : "- No merged PRs found from local GitHub query; inspect Issue #53 comments and git history.";
+  const recovery = snapshot.recoveryReports.length
+    ? snapshot.recoveryReports.map((report) => `- ${report}`).join("\n")
+    : "- No stuck reports found.";
+
+  return `# Operator Live Status — ${reportDate}
+
+Status: ${snapshot.status}
+Issue: #53
+Generated at: ${snapshot.generatedAt}
+
+## Runtime source
+
+- Env file: \`${snapshot.envPath}\`
+- Heartbeat log: \`${snapshot.heartbeatPath}\`
+- Context snapshot: \`${snapshot.env?.CONTEXT ?? "n/a"}\`
+- Summary path: \`${snapshot.env?.SUMMARY ?? "n/a"}\`
+
+## Heartbeat freshness
+
+- Heartbeat freshness: ${snapshot.status === "fresh" ? "fresh" : snapshot.status === "stale" ? "stale" : "not-running"}
+- Max age seconds: ${snapshot.maxAgeSeconds}
+- Last heartbeat age seconds: ${snapshot.ageSeconds ?? "n/a"}
+- Heartbeat count: ${snapshot.heartbeatCount}
+- Deadline: ${snapshot.deadline}
+
+## Last heartbeat
+
+- Timestamp: ${last?.timestamp ?? "n/a"}
+- Phase: ${last?.phase ?? "n/a"}
+- Branch: ${last?.branch ?? "n/a"}
+- Commit: ${last?.commit ?? "n/a"}
+- Dirty: ${String(last?.dirty ?? "n/a")}
+- Current command: ${last?.current_command ?? "n/a"}
+- Next action: ${snapshot.nextAction}
+
+## Completed issue-to-PR loops
+
+${completed}
+
+## Known recovery
+
+${recovery}
+
+## Stop rules observed
+
+- Do not call red CI complete.
+- Do not use credentials, customer data, payment, login, ads SDK, external deployment, or real GTM channels.
+- Do not enable \`ENABLE_AGENT_AUTOMERGE\`.
+- If heartbeat is stale, write a stuck report before claiming completion.
+
+## Next action
+
+${snapshot.nextAction}
+`;
+}


### PR DESCRIPTION
## 요약
- `npm run operator:live-status`를 추가해 현재 4h operator trial의 live status snapshot을 생성합니다.
- `reports/operations/operator-live-status-20260428.md`에 heartbeat freshness/count/deadline, last heartbeat, completed PRs, recovery, next action을 한 파일로 남겼습니다.
- `check:operator`가 live status script/report/package entry를 검증하도록 확장했습니다.

## 증거
- Closes #62
- 4h operator trial: #53
- Item: `items/0040-operator-live-status-report.md`
- Report: `reports/operations/operator-live-status-20260428.md`
- Deslop: changed-files-only pass, report date/check mismatch fixed
- Architect verification: APPROVED

## 로컬 검증
- `npm run operator:live-status` PASS
- `node scripts/update-operator-live-status.mjs --check --output reports/operations/operator-live-status-20260428.md` PASS
- `npm run check:operator` PASS
- `npm run check:all` PASS

## 안전 경계
- `.omx` runtime logs는 커밋하지 않고 versioned status snapshot만 남겼습니다.
- GitHub settings, secrets, external deployment, customer data, payment/login/ads SDK, real GTM, 실제 24h 실행을 변경하지 않았습니다.

## 남은 리스크
- `operator:live-status` npm script는 이번 날짜 snapshot path에 고정되어 있어 다음 날짜 장시간 run에는 path 갱신 또는 별도 daily status path가 필요합니다.
- 완료 PR 목록은 `gh pr list`에 의존하며, GitHub CLI/Auth가 없으면 명시적인 빈 목록으로 degrade됩니다.
- `--check`는 report field 존재 검증이며 freshness 값을 재계산하는 freshness gate는 `operator-watchdog`가 담당합니다.
