### PR TITLE
Agent Ops: report 4h supervised operator trial

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -35,8 +35,8 @@ Updated: 2026-04-28
 | 상태 | 개수 |
 | --- | ---: |
 | done | 29 |
-| review | 58 |
-| todo | 3 |
+| review | 59 |
+| todo | 2 |
 | blocked | 0 |
 
 ## 다음 작업

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -179,7 +179,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Add 2h supervised trial readiness gate | review | `reports/operations/operator-trial-readiness-20260428.md`, `scripts/check-operator-trial-readiness.mjs` | Time, token/context, branch, network, credential, heartbeat, CI, and automerge stop rules are checked before any real 2h run |
 | Run 2-hour supervised trial | done | Issue #33, PR #50, `reports/operations/operator-trial-20260428T025400Z.md`, `items/0023-supervised-2h-operator-trial.md` | 24회 heartbeat, watchdog fresh, PR #35-#49 completed work, green CI, failures/recovery, stop rules가 기록됨 |
 | Add live operator status report | review | `scripts/update-operator-live-status.mjs`, `reports/operations/operator-live-status-20260428.md`, `items/0040-operator-live-status-report.md` | Running trial의 heartbeat freshness, deadline, completed PRs, recovery, next action을 한 파일로 생성하고 `check:operator`가 검증함 |
-| Run 4-hour supervised trial | todo | `reports/operations/operator-trial-*.md` | At least one complete issue-to-PR loop or an honest blocker report exists; no red PR is called complete |
+| Run 4-hour supervised trial | review | `reports/operations/operator-trial-20260428T053230Z.md`, `items/0035-supervised-4h-operator-trial.md` | heartbeat 47건, merge된 PR 15개, green main CI, initial stuck report, final watchdog freshness, heartbeat gap warning이 기록됨 |
 
 ## Milestone 8: Feedback + GTM Mock Intake
 
@@ -205,7 +205,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 운영사 쪽은 Issue #53의 4h supervised trial을 runtime `.omx` heartbeat/watchdog으로 실행 중이며, trial 안의 현재 제품 작업은 Issue #82 / PR #83의 원정 tab status badge이다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 운영사 쪽은 Issue #53의 4h supervised trial을 runtime `.omx` heartbeat/watchdog으로 실행 중이며, trial은 deadline 이후 final watchdog까지 도달했고, Issue #53의 report PR 준비 단계다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.
@@ -237,4 +237,5 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 28. Issue #76 / PR #77은 merge 완료되어 원정 탭에서 첫 원정의 시간·필요 생명체·보상 요약을 보여 원정 루프 동기를 명확히 한다.
 29. Issue #78 / PR #79는 merge 완료되어 원정 시작 전 필요한 생명체 수와 시작 가능 상태를 보여 첫 수확 후 원정 전환 마찰을 줄인다.
 30. Issue #80 / PR #81은 merge 완료되어 진행 중인 원정의 남은 시간과 완료 보상 상태를 보여 idle comeback 루프를 명확히 한다.
-31. Issue #82 / PR #83은 하단 원정 탭에 진행/완료 배지를 붙여 다른 탭에서도 복귀·수령 신호를 놓치지 않게 한다.
+31. Issue #82 / PR #83은 merge 완료되어 하단 원정 탭에 진행/완료 배지를 붙여 다른 탭에서도 복귀·수령 신호를 놓치지 않게 한다.
+32. Issue #53의 4h supervised trial report는 `reports/operations/operator-trial-20260428T053230Z.md`로 작성되었고, final report PR에서 닫는다.

--- a/items/0035-supervised-4h-operator-trial.md
+++ b/items/0035-supervised-4h-operator-trial.md
@@ -1,6 +1,6 @@
 # Supervised 4h operator trial
 
-Status: in_progress
+Status: review
 Owner: agent
 Created: 2026-04-28
 Updated: 2026-04-28
@@ -31,7 +31,11 @@ Branch: runtime `.omx` + active feature branches
 - Restart context snapshot: `.omx/context/operator-4h-trial-restart-20260428T053230Z.md`
 - Restart heartbeat log: `.omx/logs/operator-4h-trial-restart-20260428T053230Z.jsonl`
 - Restart watchdog log: `.omx/logs/operator-4h-trial-watchdog-restart-20260428T053230Z.log`
-- Current product loop: Issue #54 / `items/0036-album-locked-slots.md`
+- Completed restarted-loop PRs: #55, #57, #59, #61, #63, #65, #67, #69, #71, #73, #75, #77, #79, #81, #83
+- Final report: `reports/operations/operator-trial-20260428T053230Z.md`
+- Final live status: `reports/operations/operator-live-status-20260428.md`
+- Final heartbeat count: 47; max heartbeat gap warning: 702.5s
+- Follow-up issue: #84 heartbeat daemon hardening before 24h run
 
 ## Apply Conditions
 
@@ -45,5 +49,6 @@ Branch: runtime `.omx` + active feature branches
 - `npm run operator:trial:readiness`
 - `npm run check:operator`
 - `npm run check:all`
+- Final report branch verification: `npm run operator:trial:readiness` PASS, `npm run check:operator` PASS, `npm run check:all` PASS
 - GitHub PR checks for any PR created during trial
 - Main CI after any merge

--- a/reports/operations/operator-live-status-20260428.md
+++ b/reports/operations/operator-live-status-20260428.md
@@ -2,7 +2,7 @@
 
 Status: fresh
 Issue: #53
-Generated at: 2026-04-28T06:30:13.990Z
+Generated at: 2026-04-28T09:33:15.251Z
 
 ## Runtime source
 
@@ -15,19 +15,20 @@ Generated at: 2026-04-28T06:30:13.990Z
 
 - Heartbeat freshness: fresh
 - Max age seconds: 600
-- Last heartbeat age seconds: 141
-- Heartbeat count: 12
+- Last heartbeat age seconds: 7
+- Heartbeat count: 47
 - Deadline: 2026-04-28T09:32:46.000Z
 
 ## Last heartbeat
 
-- Timestamp: 2026-04-28T06:27:53.163Z
+- Timestamp: 2026-04-28T09:33:07.801Z
 - Phase: live-trial
-- Branch: codex/operator-live-status-report
-- Commit: dde89fa
+- Branch: codex/operator-4h-trial-report
+- Commit: 2ba3b25
 - Dirty: true
-- Current command: operator 4h restart heartbeat 12
-- Next action: continue until deadline 1777368766 or stop rule
+- Current command: operator 4h restart heartbeat 47
+- Recorded next action: continue until deadline 1777368766 or stop rule
+- Superseded next action: trial deadline passed; finalize the Issue #53 report PR, then schedule the heartbeat-daemon hardening follow-up before any 24h run.
 
 ## Completed issue-to-PR loops
 
@@ -35,6 +36,17 @@ Generated at: 2026-04-28T06:30:13.990Z
 - PR #57: Game: 도감 다음 목표 CTA로 씨앗 행동 연결 (2026-04-28T05:49:13Z) — https://github.com/bborok1234/strange-seed-shop/pull/57
 - PR #59: Game: expose album next action on mobile (2026-04-28T06:04:38Z) — https://github.com/bborok1234/strange-seed-shop/pull/59
 - PR #61: Game: highlight album target seed in seed tab (2026-04-28T06:21:46Z) — https://github.com/bborok1234/strange-seed-shop/pull/61
+- PR #63: Agent Ops: generate live operator trial status report (2026-04-28T06:36:04Z) — https://github.com/bborok1234/strange-seed-shop/pull/63
+- PR #65: Game: connect target seed highlight to garden shop actions (2026-04-28T06:49:40Z) — https://github.com/bborok1234/strange-seed-shop/pull/65
+- PR #67: Game: show target seed purchase shortfall (2026-04-28T07:04:22Z) — https://github.com/bborok1234/strange-seed-shop/pull/67
+- PR #69: Game: show album progress on bottom tab (2026-04-28T07:14:21Z) — https://github.com/bborok1234/strange-seed-shop/pull/69
+- PR #71: Game: add rarity cue to garden next creature card (2026-04-28T07:25:59Z) — https://github.com/bborok1234/strange-seed-shop/pull/71
+- PR #73: Game: show seed growth and harvest summary (2026-04-28T07:37:56Z) — https://github.com/bborok1234/strange-seed-shop/pull/73
+- PR #75: Game: show next album reward milestone (2026-04-28T07:50:34Z) — https://github.com/bborok1234/strange-seed-shop/pull/75
+- PR #77: Game: show expedition reward preview (2026-04-28T08:06:00Z) — https://github.com/bborok1234/strange-seed-shop/pull/77
+- PR #79: Game: show expedition unlock hint (2026-04-28T08:19:30Z) — https://github.com/bborok1234/strange-seed-shop/pull/79
+- PR #81: Game: show expedition progress hint (2026-04-28T08:42:56Z) — https://github.com/bborok1234/strange-seed-shop/pull/81
+- PR #83: Game: show expedition status on bottom tab (2026-04-28T08:54:31Z) — https://github.com/bborok1234/strange-seed-shop/pull/83
 
 ## Known recovery
 
@@ -50,4 +62,4 @@ Generated at: 2026-04-28T06:30:13.990Z
 
 ## Next action
 
-continue until deadline 1777368766 or stop rule
+Finalize and merge the Issue #53 report PR, then create/queue heartbeat-daemon hardening before any 24h operator run.

--- a/reports/operations/operator-trial-20260428T053230Z.md
+++ b/reports/operations/operator-trial-20260428T053230Z.md
@@ -1,0 +1,115 @@
+# 4h Supervised Operator Trial Report — 2026-04-28T053230Z
+
+Status: completed-with-warning
+Issue: #53
+Restart window: 2026-04-28T05:32:46Z → 2026-04-28T09:32:46Z
+Finalized at: 2026-04-28T09:34:27.724Z
+
+## 요약
+
+이 run은 첫 시도가 첫 heartbeat 이후 종료된 것을 숨기지 않고 stuck report로 남긴 뒤 재시작했다. 재시작된 Ralph/operator 세션은 4시간 deadline 이후 final watchdog까지 도달했고, issue-to-PR loop를 반복하며 PR check, merge, main CI 확인, Issue #53 진행 코멘트를 남겼다.
+
+결과: **issue-to-PR/CI discipline 목표는 통과**했다. 다만 heartbeat gap 하나가 600초 freshness threshold를 넘었으므로 24h run 전에는 heartbeat daemon을 foreground agent loop와 더 분리해야 한다.
+
+## Runtime sources / 실행 근거
+
+- Initial context snapshot: `.omx/context/operator-4h-trial-20260428T051755Z.md`
+- Initial heartbeat log: `.omx/logs/operator-4h-trial-20260428T051755Z.jsonl`
+- Initial watchdog log: `.omx/logs/operator-4h-trial-watchdog-20260428T051755Z.log`
+- Initial stuck report: `reports/operations/stuck-20260428-4h-trial-runner-exited.md`
+- Restart context snapshot: `.omx/context/operator-4h-trial-restart-20260428T053230Z.md`
+- Restart heartbeat log: `.omx/logs/operator-4h-trial-restart-20260428T053230Z.jsonl`
+- Restart watchdog log: `.omx/logs/operator-4h-trial-watchdog-restart-20260428T053230Z.log`
+- Live status report: `reports/operations/operator-live-status-20260428.md`
+
+## Heartbeat coverage / 생존성 범위
+
+- Observed heartbeat count: 47
+- First heartbeat: 2026-04-28T05:32:46.258Z
+- Final heartbeat: 2026-04-28T09:33:07.801Z
+- Deadline: 2026-04-28T09:32:46.000Z
+- Restart run observed duration minutes: 240.4
+- Final watchdog status: fresh at 2026-04-28T09:34:27.724Z
+- Average gap seconds: 313.5
+- Max gap seconds: 702.5 (2026-04-28T08:31:22.020Z → 2026-04-28T08:43:04.495Z)
+- Coverage assessment: warning — 한 구간이 600초 freshness threshold를 넘었다. 해당 구간은 PR/CI/merge 작업 중 발생했고, deadline 이후 fresh heartbeat/watchdog evidence로 회복을 확인했다.
+
+## Completed work / 완료 작업
+
+| PR | Title | Merged at | Merge commit | Main CI |
+| --- | --- | --- | --- | --- |
+| #55 | Game: 도감 미발견 슬롯과 수집 단서 v0 | 2026-04-28T05:39:04Z | `0a292f8` | [25035961173](https://github.com/bborok1234/strange-seed-shop/actions/runs/25035961173) success |
+| #57 | Game: 도감 다음 목표 CTA로 씨앗 행동 연결 | 2026-04-28T05:49:13Z | `bf22624` | [25036273577](https://github.com/bborok1234/strange-seed-shop/actions/runs/25036273577) success |
+| #59 | Game: expose album next action on mobile | 2026-04-28T06:04:38Z | `4095877` | [25036768024](https://github.com/bborok1234/strange-seed-shop/actions/runs/25036768024) success |
+| #61 | Game: highlight album target seed in seed tab | 2026-04-28T06:21:46Z | `dde89fa` | [25037338899](https://github.com/bborok1234/strange-seed-shop/actions/runs/25037338899) success |
+| #63 | Agent Ops: generate live operator trial status report | 2026-04-28T06:36:04Z | `92128eb` | [25037826852](https://github.com/bborok1234/strange-seed-shop/actions/runs/25037826852) success |
+| #65 | Game: connect target seed highlight to garden shop actions | 2026-04-28T06:49:40Z | `c1b315e` | [25038304095](https://github.com/bborok1234/strange-seed-shop/actions/runs/25038304095) success |
+| #67 | Game: show target seed purchase shortfall | 2026-04-28T07:04:22Z | `4c6690f` | [25038858959](https://github.com/bborok1234/strange-seed-shop/actions/runs/25038858959) success |
+| #69 | Game: show album progress on bottom tab | 2026-04-28T07:14:21Z | `53c0f50` | [25039254244](https://github.com/bborok1234/strange-seed-shop/actions/runs/25039254244) success |
+| #71 | Game: add rarity cue to garden next creature card | 2026-04-28T07:25:59Z | `9560e53` | [25039718656](https://github.com/bborok1234/strange-seed-shop/actions/runs/25039718656) success |
+| #73 | Game: show seed growth and harvest summary | 2026-04-28T07:37:56Z | `32f28ff` | [25040200502](https://github.com/bborok1234/strange-seed-shop/actions/runs/25040200502) success |
+| #75 | Game: show next album reward milestone | 2026-04-28T07:50:34Z | `dd459fb` | [25040714697](https://github.com/bborok1234/strange-seed-shop/actions/runs/25040714697) success |
+| #77 | Game: show expedition reward preview | 2026-04-28T08:06:00Z | `3300f84` | [25041370768](https://github.com/bborok1234/strange-seed-shop/actions/runs/25041370768) success |
+| #79 | Game: show expedition unlock hint | 2026-04-28T08:19:30Z | `a196b84` | [25041956121](https://github.com/bborok1234/strange-seed-shop/actions/runs/25041956121) success |
+| #81 | Game: show expedition progress hint | 2026-04-28T08:42:56Z | `8d9279b` | [25042986994](https://github.com/bborok1234/strange-seed-shop/actions/runs/25042986994) success |
+| #83 | Game: show expedition status on bottom tab | 2026-04-28T08:54:31Z | `2ba3b25` | [25043499917](https://github.com/bborok1234/strange-seed-shop/actions/runs/25043499917) success |
+
+## Closed issues / 닫힌 이슈
+
+- #54: Game: 도감 미발견 슬롯과 수집 단서 v0 (2026-04-28T05:39:04Z) — https://github.com/bborok1234/strange-seed-shop/issues/54
+- #56: Game: 도감 다음 목표 CTA로 씨앗 행동 연결 (2026-04-28T05:49:14Z) — https://github.com/bborok1234/strange-seed-shop/issues/56
+- #58: Game: expose album next action on mobile (2026-04-28T06:04:39Z) — https://github.com/bborok1234/strange-seed-shop/issues/58
+- #60: Game: highlight album target seed in seed tab (2026-04-28T06:21:47Z) — https://github.com/bborok1234/strange-seed-shop/issues/60
+- #62: Agent Ops: generate live operator trial status report (2026-04-28T06:36:05Z) — https://github.com/bborok1234/strange-seed-shop/issues/62
+- #64: Game: connect target seed highlight to garden shop actions (2026-04-28T06:49:41Z) — https://github.com/bborok1234/strange-seed-shop/issues/64
+- #66: Game: show leaf shortfall for target seed purchase (2026-04-28T07:04:23Z) — https://github.com/bborok1234/strange-seed-shop/issues/66
+- #68: Game: show album progress on bottom tab (2026-04-28T07:14:23Z) — https://github.com/bborok1234/strange-seed-shop/issues/68
+- #70: Game: add rarity cue to garden next creature card (2026-04-28T07:26:00Z) — https://github.com/bborok1234/strange-seed-shop/issues/70
+- #72: Game: show seed growth and harvest summary (2026-04-28T07:37:57Z) — https://github.com/bborok1234/strange-seed-shop/issues/72
+- #74: Game: show next album reward milestone (2026-04-28T07:50:35Z) — https://github.com/bborok1234/strange-seed-shop/issues/74
+- #76: Game: show expedition reward preview (2026-04-28T08:06:01Z) — https://github.com/bborok1234/strange-seed-shop/issues/76
+- #78: Game: show expedition unlock hint (2026-04-28T08:19:32Z) — https://github.com/bborok1234/strange-seed-shop/issues/78
+- #80: Game: show expedition progress hint (2026-04-28T08:42:57Z) — https://github.com/bborok1234/strange-seed-shop/issues/80
+- #82: Game: show expedition status on bottom tab (2026-04-28T08:54:32Z) — https://github.com/bborok1234/strange-seed-shop/issues/82
+
+## Failures and recovery attempts / 실패와 복구
+
+- Initial attempt는 첫 heartbeat 이후 background runner PID가 사라졌다. 이를 성공으로 포장하지 않고 `reports/operations/stuck-20260428-4h-trial-runner-exited.md`로 기록했다.
+- 재시작은 `.omx/logs/operator-4h-trial-restart-current.env`와 `.omx/logs/operator-4h-trial-restart-20260428T053230Z.jsonl`를 기준으로 진행했다.
+- Browser Use direct iab execution tool은 계속 노출되지 않았다. Visual evidence는 기록된 CDP fallback path를 사용했고, 영향을 받은 item마다 fallback을 남겼다.
+- 일부 PR merge는 branch-policy timing 때문에 즉시 실패했다. Operator는 ready-triggered checks를 기다린 뒤 `--admin`이나 branch-protection 우회 없이 merge했다.
+- 한 heartbeat gap이 702.5초로 600초를 초과했다. 이 run은 이를 숨기지 않고 liveness warning으로 분류한다.
+
+## CI status / 검증 상태
+
+- 재시작 window에서 merge된 모든 PR은 merge 전 green PR checks를 확인했다.
+- 표에 적힌 모든 main CI run은 success다.
+- Report finalization 직전 최신 local post-merge verification: PR #83 / merge `2ba3b25` 이후 `npm run check:all` PASS.
+- Final report branch verification은 아래 최종 보고서 브랜치 검증 섹션에 기록한다.
+
+## Final report branch verification / 최종 보고서 브랜치 검증
+
+- `npm run operator:trial:readiness` PASS
+- `npm run check:operator` PASS
+- `npm run check:all` PASS
+- Architect verification: APPROVED
+- Changed-files-only deslop pass: PASS (`.omx/state/operator-4h-trial-report/deslop-report-20260428.md`)
+
+## Stop rules observed / 준수한 중단 규칙
+
+- Credential, customer data, real payment, login/account, ads SDK, external deployment, real GTM channel action을 사용하지 않았다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜지 않았다.
+- `--admin` merge나 branch-protection bypass를 사용하지 않았다.
+- Red/pending CI를 완료로 부르지 않았다. PR은 required checks가 통과한 뒤에만 merge했고, merge 후 main CI를 확인했다.
+
+## Daily report summary / 일일 보고 요약
+
+- Product axis: collection desire, purchase clarity, expedition motivation, idle comeback signal, always-visible progress/status cue가 개선되었다.
+- Operating-company axis: session이 issue 생성, branch, draft PR, local verification, review/deslop evidence, PR checks, main CI evidence, Issue #53 progress comment를 반복 수행했다.
+- 24h run 전 remaining gap: 긴 CI/PR phase가 heartbeat gap을 만들지 않도록 heartbeat/reporting을 foreground agent loop와 더 분리해야 한다.
+
+## Next queue / 다음 대기열
+
+1. 이 report PR을 열고 merge해 Issue #53을 닫는다.
+2. Follow-up issue #84: 24h dry run 전 긴 PR/CI wait 중에도 heartbeat daemon이 stale 상태가 되지 않도록 보강한다.
+3. Report PR이 green이면 roadmap의 다음 Phase 0 game/operator 작업을 이어간다.


### PR DESCRIPTION
## 요약

- Issue #53의 4h supervised operator trial 최종 보고서를 추가합니다.
- Restart window `2026-04-28T05:32:46Z → 2026-04-28T09:32:46Z`의 heartbeat/PR/CI evidence를 정리합니다.
- 15개 issue-to-PR loop, 47 heartbeat, final watchdog fresh, initial stuck report, 702.5s heartbeat gap warning을 숨기지 않고 기록합니다.
- 24h run 전 보강 follow-up issue #84를 생성했습니다.

## 검증

- `npm run operator:trial:readiness` PASS
- `npm run check:operator` PASS
- `npm run check:all` PASS
- Final watchdog after deadline: fresh
- Architect verification: APPROVED
- Changed-files-only deslop pass: PASS

## 안전 범위

- 문서/운영 보고서 변경만 포함
- credentials/customer data/payment/login/ads/external deployment/real GTM 없음
- `ENABLE_AGENT_AUTOMERGE` 변경 없음
- main branch protection 우회 없음

Closes #53
Related #84
