### PR TITLE
Agent Ops: harden heartbeat daemon before 24h run

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -35,7 +35,7 @@ Updated: 2026-04-28
 | 상태 | 개수 |
 | --- | ---: |
 | done | 29 |
-| review | 59 |
+| review | 60 |
 | todo | 2 |
 | blocked | 0 |
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -41,15 +41,19 @@ Before any supervised 4h or 24h run:
    - `npm run check:all`
 5. Write initial heartbeat:
    - `node scripts/write-operator-heartbeat.mjs --issue '#<n>' --item items/<id>.md --phase executing --iteration 1 --command '<current command>' --next '<next action>' --context <snapshot>`
-6. Announce/record start only after the heartbeat and readiness checks exist.
+6. For 4h+ or 24h dry-run windows, start an independent heartbeat daemon before long PR/CI waits:
+   - `npm run operator:heartbeat:daemon -- --issue '#<n>' --item items/<id>.md --interval-seconds 300 --heartbeat .omx/state/operator-heartbeat.json --report .omx/logs/operator-<run>.jsonl --summary .omx/state/operator-heartbeat-daemon-summary.json`
+7. Announce/record start only after the heartbeat, daemon summary, and readiness checks exist.
 
 ## Monitor procedure
 
 During a supervised run:
 
 - Write heartbeat at least once per iteration and at least every 5 minutes during multi-hour trials.
+- During long PR/CI waits, the independent heartbeat daemon owns the 5-minute liveness signal; the foreground agent still records meaningful phase transitions.
 - Run watchdog against the current heartbeat source:
   - `npm run operator:watchdog -- --heartbeat <path> --max-age-seconds 600 --report <report-path>`
+  - add `--stuck-output <stuck-report-path>` when the watchdog should write the stale report automatically.
 - Keep every issue-to-PR loop evidence-backed:
   - issue/work item
   - branch
@@ -69,7 +73,7 @@ When something goes wrong, do not continue silently.
 | State | Required action |
 | --- | --- |
 | Red CI | Inspect `gh run view --log`, write cause/fix attempt, rerun checks, or file blocker report. |
-| Stale heartbeat | Run watchdog, write stuck report, restart only after recording the stale state. |
+| Stale heartbeat | Run watchdog with `--stuck-output`, write stuck report, restart only after recording the stale state. |
 | Merge conflict | Stop the merge, inspect conflict, rebase/resolve on a branch, rerun local checks. |
 | Browser Use blocked | Read `browser-use:browser` skill, record direct blocker, use accepted fallback only with evidence. |
 | External credential needed | Stop and mark blocked; do not ask the human to paste secrets into reports. |
@@ -138,6 +142,7 @@ The future 24h dry run additionally requires:
 
 - 4h supervised trial report merged.
 - Daily report produced from a real multi-hour run.
+- Heartbeat daemon hardening report exists and `npm run operator:trial:gap-guard` plus `npm run operator:watchdog:stuck-guard` pass.
 - Red-CI recovery drill or blocker drill evidence still current.
 - Browser Use fallback status current.
 - No real credentials or external channel actions required.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -180,6 +180,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Run 2-hour supervised trial | done | Issue #33, PR #50, `reports/operations/operator-trial-20260428T025400Z.md`, `items/0023-supervised-2h-operator-trial.md` | 24회 heartbeat, watchdog fresh, PR #35-#49 completed work, green CI, failures/recovery, stop rules가 기록됨 |
 | Add live operator status report | review | `scripts/update-operator-live-status.mjs`, `reports/operations/operator-live-status-20260428.md`, `items/0040-operator-live-status-report.md` | Running trial의 heartbeat freshness, deadline, completed PRs, recovery, next action을 한 파일로 생성하고 `check:operator`가 검증함 |
 | Run 4-hour supervised trial | review | `reports/operations/operator-trial-20260428T053230Z.md`, `items/0035-supervised-4h-operator-trial.md` | heartbeat 47건, merge된 PR 15개, green main CI, initial stuck report, final watchdog freshness, heartbeat gap warning이 기록됨 |
+| Harden heartbeat daemon before 24h run | review | Issue #84, `scripts/operator-heartbeat-daemon.mjs`, `reports/operations/heartbeat-daemon-hardening-20260428.md`, `items/0051-heartbeat-daemon-hardening.md` | 독립 heartbeat daemon, stale-gap dry-run guard, watchdog stuck-output guard로 600초 초과 gap을 완료로 오인하지 않게 한다 |
 
 ## Milestone 8: Feedback + GTM Mock Intake
 
@@ -205,7 +206,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. 운영사 쪽은 Issue #53의 4h supervised trial을 runtime `.omx` heartbeat/watchdog으로 실행 중이며, trial은 deadline 이후 final watchdog까지 도달했고, Issue #53의 report PR 준비 단계다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report는 PR #85로 merge되어 닫혔고, 현재 안전한 다음 작업은 Issue #84의 heartbeat daemon hardening을 PR로 검증·merge하는 것이다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.
@@ -223,7 +224,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 14. 24시간 봇, 고객 피드백 실채널, GTM 실게시, 광고/결제/계정/credential 사용은 Milestone 6-8의 안전 장치와 명시 승인이 생기기 전까지 금지한다.
 15. 실제 결제, 로그인/account, ads SDK, external navigation, runtime image generation은 계속 제외한다.
 16. Issue #51은 4h/24h 운영 전에 필요한 operator runbook과 daily operating report 템플릿을 만드는 작업이며, 실제 4h/24h 실행은 이 문서/checker PR이 merge되기 전 시작하지 않는다.
-17. Issue #53은 4h supervised trial로 실행 중이며, runtime heartbeat log는 `.omx/logs/operator-4h-trial-20260428T051755Z.jsonl`이다. Issue #54는 trial 안에서 수행하는 첫 게임 feature loop로 도감 미발견 슬롯을 추가한다.
+17. Issue #53의 4h supervised trial은 PR #85로 보고서가 merge되어 닫혔고, Issue #84가 24h run 전 heartbeat gap 보강 follow-up으로 열렸다.
 18. Issue #56은 도감 다음 목표 카드에서 씨앗 탭으로 이어지는 CTA를 추가해 Issue #54의 미발견 슬롯 단서를 실제 다음 행동으로 연결한다.
 19. Issue #58은 모바일 도감 첫 화면에서도 다음 발견 생명체와 씨앗 행동이 보이도록 상단 compact CTA chip을 추가한다.
 20. Issue #60은 도감 CTA 이후 씨앗 탭에서 다음 도감 목표 씨앗과 해당 row를 강조해 구매/심기 행동 전환을 돕는다.
@@ -238,4 +239,5 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 29. Issue #78 / PR #79는 merge 완료되어 원정 시작 전 필요한 생명체 수와 시작 가능 상태를 보여 첫 수확 후 원정 전환 마찰을 줄인다.
 30. Issue #80 / PR #81은 merge 완료되어 진행 중인 원정의 남은 시간과 완료 보상 상태를 보여 idle comeback 루프를 명확히 한다.
 31. Issue #82 / PR #83은 merge 완료되어 하단 원정 탭에 진행/완료 배지를 붙여 다른 탭에서도 복귀·수령 신호를 놓치지 않게 한다.
-32. Issue #53의 4h supervised trial report는 `reports/operations/operator-trial-20260428T053230Z.md`로 작성되었고, final report PR에서 닫는다.
+32. Issue #53의 4h supervised trial report는 `reports/operations/operator-trial-20260428T053230Z.md`로 작성되었고, PR #85로 merge되어 닫혔다.
+33. Issue #84는 24h run 전 heartbeat daemon hardening 작업으로, 4h trial에서 드러난 702.5초 gap을 dry-run failure와 watchdog stuck report로 고정한다.

--- a/items/0051-heartbeat-daemon-hardening.md
+++ b/items/0051-heartbeat-daemon-hardening.md
@@ -1,0 +1,48 @@
+# Heartbeat daemon hardening before 24h run
+
+Status: review
+Owner: agent
+Created: 2026-04-28
+Updated: 2026-04-28
+Scope-risk: moderate
+Work type: agent_ops
+Issue: #84
+Branch: codex/heartbeat-daemon-hardening
+
+## Intent
+
+Issue #53의 4h supervised trial은 issue-to-PR loop와 CI discipline은 통과했지만, PR/CI/merge 작업 중 heartbeat gap이 702.5초로 600초 freshness threshold를 초과했다. 24h run 전 heartbeat/reporting을 foreground agent loop와 분리하고, gap 초과를 dry-run failure로 고정한다.
+
+## Acceptance Criteria
+
+- heartbeat daemon runner가 별도 process에서 5분 이하 주기로 heartbeat를 쓸 수 있다.
+- watchdog이 stale heartbeat를 감지하면 stuck report를 자동으로 남길 수 있다.
+- dry-run fixture가 600초 초과 heartbeat gap을 `dry-run-review` / non-zero exit로 분류한다.
+- `npm run operator:trial:gap-guard`, `npm run operator:watchdog:stuck-guard`, `npm run check:operator`, `npm run check:all`이 통과한다.
+- credentials/customer data/payment/login/ads/external deployment/real GTM은 건드리지 않는다.
+
+## Evidence
+
+- Follow-up issue: https://github.com/bborok1234/strange-seed-shop/issues/84
+- 4h source warning: `reports/operations/operator-trial-20260428T053230Z.md`
+- Daemon script: `scripts/operator-heartbeat-daemon.mjs`
+- Gap guard: `scripts/check-operator-trial-gap-guard.mjs`
+- Stuck-report guard: `scripts/check-operator-watchdog-stuck-report.mjs`
+- Stale gap fixture: `reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json`
+- Stale gap report: `reports/operations/operator-trial-stale-gap-guard-20260428.md`
+- Hardening report: `reports/operations/heartbeat-daemon-hardening-20260428.md`
+
+## Apply Conditions
+
+- 실제 고객 데이터, credential, 결제, 로그인/account, ads SDK, external deployment, 실채널 GTM을 건드리지 않는다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜지 않는다.
+- Branch protection과 required checks를 우회하지 않는다.
+- Stale heartbeat를 완료로 부르지 않는다.
+
+## Verification
+
+- `npm run operator:trial:dry-run`
+- `npm run operator:trial:gap-guard`
+- `npm run operator:watchdog:stuck-guard`
+- `npm run check:operator`
+- `npm run check:all`

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check:governance": "node scripts/check-governance.mjs",
     "update:pr-audit": "node scripts/update-pr-automation-audit.mjs",
     "check:audit": "node scripts/check-audit-reports.mjs",
-    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:browser-qa && npm run check:sprite-batch && npm run check:asset-normalization && npm run check:playtest-intake && npm run check:gtm-mock && npm run check:operator && npm run check:governance && npm run check:audit && npm run build",
+    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:browser-qa && npm run check:sprite-batch && npm run check:asset-normalization && npm run check:playtest-intake && npm run check:gtm-mock && npm run operator:trial:gap-guard && npm run operator:watchdog:stuck-guard && npm run check:operator && npm run check:governance && npm run check:audit && npm run build",
     "check:sprite-batch": "node scripts/check-sprite-batch.mjs",
     "check:operator": "node scripts/check-operator.mjs",
     "operator:watchdog": "node scripts/operator-watchdog.mjs",
@@ -29,7 +29,10 @@
     "check:playtest-intake": "node scripts/check-playtest-intake.mjs",
     "check:gtm-mock": "node scripts/check-gtm-mock.mjs",
     "check:asset-normalization": "node scripts/check-asset-normalization.mjs",
-    "operator:live-status": "node scripts/update-operator-live-status.mjs --output reports/operations/operator-live-status-20260428.md"
+    "operator:live-status": "node scripts/update-operator-live-status.mjs --output reports/operations/operator-live-status-20260428.md",
+    "operator:heartbeat:daemon": "node scripts/operator-heartbeat-daemon.mjs",
+    "operator:trial:gap-guard": "node scripts/check-operator-trial-gap-guard.mjs",
+    "operator:watchdog:stuck-guard": "node scripts/check-operator-watchdog-stuck-report.mjs"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/reports/operations/README.md
+++ b/reports/operations/README.md
@@ -7,16 +7,19 @@
 | 파일 | 목적 |
 | --- | --- |
 | `operator-heartbeat-YYYYMMDD.jsonl` | Ralph/session heartbeat ledger. timestamp, phase, branch, issue, PR, current command, next action을 JSONL로 누적한다. |
+| `operator-heartbeat-daemon*.json` / `.jsonl` | 4h+ 또는 24h dry-run에서 foreground agent loop와 분리된 liveness proof를 남긴다. |
 | `operator-loop-YYYYMMDD.md` | issue-to-PR loop report. issue, branch, commits, local checks, GitHub checks, follow-up evidence를 요약한다. |
 | `operator-completion-gate-YYYYMMDD.md` | 작업 완료 gate report. issue, draft PR, verification, audit/follow-up 링크가 완료 선언 전에 모두 존재하는지 기록한다. |
 | `stuck-*.md` / `stuck-drill-*.md` | stuck report. `collab: Wait`, stale tmux, red CI, timeout, orphan process가 완료로 오인되지 않게 한다. |
 | `operator-trial-*.md` | Milestone 7 이후 다시간 trial report. heartbeat coverage, completed work, recovery attempts를 기록한다. |
+| `operator-trial-stale-gap-guard-*.md` | 600초 초과 heartbeat gap fixture가 dry-run failure/review로 분류되는지 검증한다. |
 | `operator-trial-20260428T025400Z.md` | Issue #33의 실제 2h supervised trial report. 24회 heartbeat, PR #35-#49 completed work, CI status, Stop rules observed, Next queue를 고정한다. |
 | `daily-*.md` / `daily-template-*.md` | 장시간 operator 세션의 daily operating report. completed work, failed work, open PRs, red checks, decisions, next queue를 사람이 아침에 바로 읽을 수 있게 고정한다. |
 
 ## 최소 증거 기준
 
-- heartbeat는 iteration마다 한 번 이상 기록한다.
+- heartbeat는 iteration마다 한 번 이상 기록하고, 4h+ 또는 24h dry-run에서는 독립 heartbeat daemon으로 5분 이하 liveness를 유지한다.
+- watchdog stale 상태는 `--stuck-output` report를 남긴 뒤 recovery 또는 blocker로 분류한다.
 - red CI는 `CI repair` 절차에 따라 로그 URL, 원인 가설, 수정 시도, 재검증 또는 blocker report를 남긴다.
 - issue-to-PR 루프는 main merge 여부와 무관하게 PR URL과 GitHub check 상태를 남긴다.
 - 작업 완료 gate는 draft PR, 검증 명령, visual evidence 또는 N/A 사유, 남은 위험, follow-up issue/audit 링크를 한 report에 함께 남긴다.

--- a/reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json
+++ b/reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json
@@ -4,7 +4,9 @@
   "started_at": "2026-04-28T02:40:00.000Z",
   "ended_at": "2026-04-28T02:50:00.000Z",
   "operator_branch": "codex/operator-trial-dry-run",
-  "related_issues": ["#29"],
+  "related_issues": [
+    "#29"
+  ],
   "related_prs": [],
   "human_approved_budget": "dry-run only; no real 2h/4h/24h execution",
   "heartbeat_windows": [
@@ -13,14 +15,16 @@
       "expected": 1,
       "observed": 1,
       "freshness": "fresh",
-      "evidence": "fixture heartbeat at 2026-04-28T02:42:00.000Z"
+      "evidence": "fixture heartbeat at 2026-04-28T02:42:00.000Z",
+      "max_gap_seconds": 300
     },
     {
       "window": "5-10m",
       "expected": 1,
       "observed": 1,
       "freshness": "fresh",
-      "evidence": "fixture heartbeat at 2026-04-28T02:47:00.000Z"
+      "evidence": "fixture heartbeat at 2026-04-28T02:47:00.000Z",
+      "max_gap_seconds": 300
     }
   ],
   "completed_work": [
@@ -59,5 +63,8 @@
     "Stale heartbeat becomes reportable state, not completion",
     "Repeated failure would become blocker report after 3 attempts"
   ],
-  "next_queue": ["#29 PR checks", "future real supervised 2h trial after explicit report readiness"]
+  "next_queue": [
+    "#29 PR checks",
+    "future real supervised 2h trial after explicit report readiness"
+  ]
 }

--- a/reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json
+++ b/reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json
@@ -1,0 +1,61 @@
+{
+  "trial_id": "operator-trial-stale-gap-guard-20260428",
+  "mode": "deterministic-stale-gap-guard",
+  "started_at": "2026-04-28T08:30:00.000Z",
+  "ended_at": "2026-04-28T08:45:00.000Z",
+  "operator_branch": "codex/heartbeat-daemon-hardening",
+  "related_issues": [
+    "#84"
+  ],
+  "related_prs": [],
+  "human_approved_budget": "dry-run fixture only; no real 24h execution",
+  "heartbeat_windows": [
+    {
+      "window": "PR/CI wait 0-15m",
+      "expected": 3,
+      "observed": 3,
+      "max_gap_seconds": 702.5,
+      "freshness": "stale-gap",
+      "evidence": "fixture reproduces Issue #53 max gap 702.5s over 600s threshold"
+    }
+  ],
+  "completed_work": [
+    {
+      "item": "items/0051-heartbeat-daemon-hardening.md",
+      "status": "gap-guard-fixture",
+      "evidence": "reports/operations/operator-trial-stale-gap-guard-20260428.md"
+    }
+  ],
+  "failures": [
+    {
+      "failure": "heartbeat gap exceeded threshold during PR/CI wait",
+      "detection_source": "operator-trial-dry-run max_gap_seconds guard",
+      "recovery_attempt": "classify as dry-run-review and require heartbeat daemon hardening",
+      "result": "reported-stale-gap",
+      "follow_up": "Issue #84"
+    }
+  ],
+  "ci_status": [
+    {
+      "pr": "pending",
+      "check": "Verify game baseline",
+      "result": "expected-pass-after-pr",
+      "url": "pending"
+    },
+    {
+      "pr": "pending",
+      "check": "Check automerge eligibility",
+      "result": "expected-pass-after-pr",
+      "url": "pending"
+    }
+  ],
+  "stop_rules_observed": [
+    "No real 24h execution in stale-gap guard",
+    "No credentials, customer data, external deployment, real GTM, payment/login/ads SDK",
+    "A gap above 600 seconds becomes dry-run-review, not completion"
+  ],
+  "next_queue": [
+    "harden heartbeat daemon",
+    "rerun operator:trial:gap-guard"
+  ]
+}

--- a/reports/operations/heartbeat-daemon-hardening-20260428.md
+++ b/reports/operations/heartbeat-daemon-hardening-20260428.md
@@ -1,0 +1,42 @@
+# Heartbeat Daemon Hardening Report — 2026-04-28
+
+Status: review
+Issue: #84
+Scope-risk: moderate
+
+## 요약
+
+Issue #53의 4h trial에서 발견된 702.5초 heartbeat gap을 24h run 전 차단하기 위해 heartbeat daemon runner, stale-gap dry-run guard, watchdog stuck-report guard를 추가했다.
+
+## 변경 사항
+
+- `scripts/operator-heartbeat-daemon.mjs`: 별도 process로 즉시 heartbeat를 쓰고, 지정 interval마다 heartbeat JSON/JSONL과 summary/pid 파일을 갱신한다.
+- `scripts/operator-trial-dry-run.mjs`: `max_gap_seconds`와 `--max-gap-seconds`를 평가해 600초 초과 gap을 `dry-run-review`로 분류한다.
+- `scripts/check-operator-trial-gap-guard.mjs`: 702.5초 gap fixture가 반드시 실패하는지 검증한다.
+- `scripts/operator-watchdog.mjs`: stale/missing/invalid heartbeat일 때 `--stuck-output` report를 남긴다.
+- `scripts/check-operator-watchdog-stuck-report.mjs`: stale watchdog이 non-zero로 끝나고 stuck report를 쓰는지 검증한다.
+
+## Evidence
+
+- Normal dry-run: `reports/operations/operator-trial-dry-run-20260428.md` — `Status: dry-run-pass`, `Stale gap windows: 0`.
+- Stale gap guard: `reports/operations/operator-trial-stale-gap-guard-20260428.md` — `Status: dry-run-review`, `Stale gap windows: 1`, `702.5`.
+- Daemon proof: `.omx/logs/heartbeat-daemon-proof.jsonl` — 1초 interval, 2 heartbeat, watchdog fresh.
+- Watchdog stuck proof: `.omx/state/watchdog-stuck-guard-report.md` — stale heartbeat age 660s over 600s threshold recorded as `Status: reported`.
+
+## Verification
+
+- `npm run operator:trial:dry-run` PASS
+- `npm run operator:trial:gap-guard` PASS
+- `npm run operator:watchdog:stuck-guard` PASS
+- `npm run check:operator` PASS
+- `npm run check:all` PASS
+
+## Safety
+
+- No credentials, customer data, payment, login/account, ads SDK, external deployment, or real GTM channel action.
+- `ENABLE_AGENT_AUTOMERGE` remains disabled.
+- No branch protection bypass.
+
+## Remaining risk
+
+This does not run a real 24h session. It only makes the next 24h dry run safer by failing stale-gap fixtures and giving the operator a separate heartbeat process to start before long waits.

--- a/reports/operations/operator-trial-dry-run-20260428.md
+++ b/reports/operations/operator-trial-dry-run-20260428.md
@@ -18,11 +18,13 @@ Scope-risk: moderate
 - Expected heartbeat count: 2
 - Observed heartbeat count: 2
 - Coverage: 100%
+- Max allowed gap seconds: 600
+- Stale gap windows: 0
 
-| Window | Expected | Observed | Freshness | Evidence |
-| --- | --- | --- | --- | --- |
-| 0-5m | 1 | 1 | fresh | fixture heartbeat at 2026-04-28T02:42:00.000Z |
-| 5-10m | 1 | 1 | fresh | fixture heartbeat at 2026-04-28T02:47:00.000Z |
+| Window | Expected | Observed | Max gap seconds | Freshness | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| 0-5m | 1 | 1 | 300 | fresh | fixture heartbeat at 2026-04-28T02:42:00.000Z |
+| 5-10m | 1 | 1 | 300 | fresh | fixture heartbeat at 2026-04-28T02:47:00.000Z |
 
 ## Completed work
 

--- a/reports/operations/operator-trial-stale-gap-guard-20260428.md
+++ b/reports/operations/operator-trial-stale-gap-guard-20260428.md
@@ -1,0 +1,56 @@
+# Operator Trial Dry Run - operator-trial-stale-gap-guard-20260428
+
+Status: dry-run-review
+Mode: deterministic-stale-gap-guard
+Scope-risk: moderate
+
+## Trial metadata
+
+- Started at: 2026-04-28T08:30:00.000Z
+- Ended at: 2026-04-28T08:45:00.000Z
+- Operator branch: `codex/heartbeat-daemon-hardening`
+- Related issues: #84
+- Related PRs: pending
+- Human-approved budget: dry-run fixture only; no real 24h execution
+
+## Heartbeat coverage
+
+- Expected heartbeat count: 3
+- Observed heartbeat count: 3
+- Coverage: 100%
+- Max allowed gap seconds: 600
+- Stale gap windows: 1
+
+| Window | Expected | Observed | Max gap seconds | Freshness | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| PR/CI wait 0-15m | 3 | 3 | 702.5 | stale-gap | fixture reproduces Issue #53 max gap 702.5s over 600s threshold |
+
+## Completed work
+
+| Item | Status | Evidence |
+| --- | --- | --- |
+| items/0051-heartbeat-daemon-hardening.md | gap-guard-fixture | reports/operations/operator-trial-stale-gap-guard-20260428.md |
+
+## Failures and recovery attempts
+
+| Failure | Detection source | Recovery attempt | Result | Follow-up |
+| --- | --- | --- | --- | --- |
+| heartbeat gap exceeded threshold during PR/CI wait | operator-trial-dry-run max_gap_seconds guard | classify as dry-run-review and require heartbeat daemon hardening | reported-stale-gap | Issue #84 |
+
+## CI status
+
+| PR | Check | Result | URL |
+| --- | --- | --- | --- |
+| pending | Verify game baseline | expected-pass-after-pr | pending |
+| pending | Check automerge eligibility | expected-pass-after-pr | pending |
+
+## Stop rules observed
+
+- No real 24h execution in stale-gap guard
+- No credentials, customer data, external deployment, real GTM, payment/login/ads SDK
+- A gap above 600 seconds becomes dry-run-review, not completion
+
+## Next queue
+
+- harden heartbeat daemon
+- rerun operator:trial:gap-guard

--- a/scripts/check-operator-trial-gap-guard.mjs
+++ b/scripts/check-operator-trial-gap-guard.mjs
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const scenario = "reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json";
+const output = "reports/operations/operator-trial-stale-gap-guard-20260428.md";
+const result = spawnSync(process.execPath, [
+  "scripts/operator-trial-dry-run.mjs",
+  "--scenario", scenario,
+  "--output", output,
+  "--max-gap-seconds", "600"
+], { encoding: "utf8" });
+
+const failures = [];
+
+if (result.status === 0) failures.push("stale gap fixture unexpectedly passed");
+if (!fs.existsSync(output)) failures.push(`missing stale gap report: ${output}`);
+
+if (fs.existsSync(output)) {
+  const report = fs.readFileSync(output, "utf8");
+  for (const phrase of [
+    "Status: dry-run-review",
+    "Max allowed gap seconds: 600",
+    "Stale gap windows: 1",
+    "702.5",
+    "stale-gap"
+  ]) {
+    if (!report.includes(phrase)) failures.push(`${output} missing phrase: ${phrase}`);
+  }
+}
+
+console.log(JSON.stringify({ ok: failures.length === 0, scenario, output, dryRunExitStatus: result.status, failures }, null, 2));
+if (failures.length > 0) process.exit(1);

--- a/scripts/check-operator-watchdog-stuck-report.mjs
+++ b/scripts/check-operator-watchdog-stuck-report.mjs
@@ -1,0 +1,54 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+
+const heartbeat = ".omx/state/watchdog-stuck-guard-heartbeat.json";
+const report = ".omx/state/watchdog-stuck-guard-report.md";
+fs.mkdirSync(".omx/state", { recursive: true });
+fs.writeFileSync(heartbeat, `${JSON.stringify({
+  schemaVersion: 1,
+  kind: "operator-heartbeat",
+  timestamp: "2026-04-28T00:00:00.000Z",
+  actor: "codex-ralph",
+  phase: "stale-guard",
+  iteration: 1,
+  issue: "#84",
+  pr: "",
+  item: "items/0051-heartbeat-daemon-hardening.md",
+  branch: "codex/heartbeat-daemon-hardening",
+  commit: "fixture",
+  dirty: false,
+  current_command: "fixture stale wait",
+  next_action: "write stuck report",
+  context_snapshot_path: ".omx/context/heartbeat-daemon-hardening-fixture.md",
+  status: "running",
+  cwd: process.cwd()
+}, null, 2)}\n`);
+
+const result = spawnSync(process.execPath, [
+  "scripts/operator-watchdog.mjs",
+  "--heartbeat", heartbeat,
+  "--now", "2026-04-28T00:11:00.000Z",
+  "--max-age-seconds", "600",
+  "--stuck-output", report,
+  "--next", "write stuck report before completion",
+  "--fail-on-stale"
+], { encoding: "utf8" });
+
+const failures = [];
+if (result.status === 0) failures.push("stale watchdog unexpectedly exited 0");
+if (!fs.existsSync(report)) failures.push(`missing watchdog stuck report: ${report}`);
+
+if (fs.existsSync(report)) {
+  const content = fs.readFileSync(report, "utf8");
+  for (const phrase of [
+    "Status: reported",
+    "heartbeat age 660s exceeds 600s",
+    "write stuck report before completion",
+    "Issue: #84"
+  ]) {
+    if (!content.includes(phrase)) failures.push(`${report} missing phrase: ${phrase}`);
+  }
+}
+
+console.log(JSON.stringify({ ok: failures.length === 0, watchdogExitStatus: result.status, report, failures }, null, 2));
+if (failures.length > 0) process.exit(1);

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -42,19 +42,27 @@ const requiredPaths = [
   "items/0023-supervised-2h-operator-trial.md",
   "items/0034-operator-runbook-daily-report.md",
   "items/0040-operator-live-status-report.md",
+  "items/0051-heartbeat-daemon-hardening.md",
   "items/0029-operator-completion-gate.md",
   "docs/OPERATOR_RUNBOOK.md",
   "reports/operations/operator-trial-readiness-20260428.md",
   "reports/operations/operator-trial-20260428T025400Z.md",
+  "reports/operations/operator-trial-20260428T053230Z.md",
   "reports/operations/daily-template-20260428.md",
   "reports/operations/operator-live-status-20260428.md",
+  "reports/operations/heartbeat-daemon-hardening-20260428.md",
   "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json",
+  "reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json",
   "reports/operations/operator-trial-dry-run-20260428.md",
+  "reports/operations/operator-trial-stale-gap-guard-20260428.md",
   "scripts/write-operator-heartbeat.mjs",
+  "scripts/operator-heartbeat-daemon.mjs",
   "scripts/update-operator-live-status.mjs",
   "scripts/operator-trial-dry-run.mjs",
+  "scripts/check-operator-trial-gap-guard.mjs",
   "scripts/check-operator-trial-readiness.mjs",
   "scripts/operator-watchdog.mjs",
+  "scripts/check-operator-watchdog-stuck-report.mjs",
   "scripts/report-operator-stuck.mjs",
   "scripts/check-operator.mjs",
   "docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md",
@@ -120,6 +128,8 @@ requirePhrases("reports/operations/operator-trial-dry-run-20260428.md", [
   "Status: dry-run-pass",
   "Heartbeat coverage",
   "Coverage: 100%",
+  "Max allowed gap seconds: 600",
+  "Stale gap windows: 0",
   "Failures and recovery attempts",
   "simulated stale heartbeat",
   "Stop rules observed",
@@ -129,7 +139,47 @@ requirePhrases("reports/operations/operator-trial-dry-run-20260428.md", [
 requirePhrases("reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json", [
   "deterministic-dry-run",
   "heartbeat_windows",
+  "max_gap_seconds",
   "stop_rules_observed"
+]);
+
+requirePhrases("items/0051-heartbeat-daemon-hardening.md", [
+  "Status: review",
+  "Work type: agent_ops",
+  "Issue: #84",
+  "heartbeat daemon",
+  "702.5초",
+  "npm run operator:trial:gap-guard",
+  "npm run operator:watchdog:stuck-guard",
+  "npm run check:all"
+]);
+
+requirePhrases("reports/operations/heartbeat-daemon-hardening-20260428.md", [
+  "Status: review",
+  "Issue: #84",
+  "Heartbeat Daemon Hardening",
+  "702.5초",
+  "operator-heartbeat-daemon.mjs",
+  "Stale gap windows: 1",
+  "npm run operator:trial:gap-guard",
+  "npm run operator:watchdog:stuck-guard"
+]);
+
+requirePhrases("reports/operations/operator-trial-stale-gap-guard-20260428.md", [
+  "Status: dry-run-review",
+  "Max allowed gap seconds: 600",
+  "Stale gap windows: 1",
+  "702.5",
+  "stale-gap",
+  "Issue #84"
+]);
+
+requirePhrases("reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json", [
+  "deterministic-stale-gap-guard",
+  "max_gap_seconds",
+  "702.5",
+  "reported-stale-gap",
+  "Issue #84"
 ]);
 
 
@@ -219,6 +269,10 @@ requirePhrases("docs/OPERATOR_RUNBOOK.md", [
   "Summarize procedure",
   "4h supervised trial readiness checklist",
   "24h dry-run readiness checklist",
+  "operator:heartbeat:daemon",
+  "operator:trial:gap-guard",
+  "operator:watchdog:stuck-guard",
+  "--stuck-output",
   "No credential access",
   "Do not call red CI"
 ]);
@@ -271,7 +325,9 @@ requirePhrases("scripts/update-operator-live-status.mjs", [
 
 requirePhrases("reports/operations/README.md", [
   "heartbeat",
+  "heartbeat daemon",
   "stuck report",
+  "--stuck-output",
   "CI repair",
   "issue-to-PR",
   "operator-completion-gate-YYYYMMDD.md",
@@ -322,9 +378,15 @@ requirePhrases("docs/PR_AUTOMATION.md", [
 requirePhrases("package.json", [
   "check:operator",
   "operator:watchdog",
+  "operator:heartbeat:daemon",
   "operator:trial:dry-run",
+  "operator:trial:gap-guard",
+  "operator:watchdog:stuck-guard",
   "operator:trial:readiness",
   "operator:live-status",
+  "scripts/operator-heartbeat-daemon.mjs",
+  "scripts/check-operator-trial-gap-guard.mjs",
+  "scripts/check-operator-watchdog-stuck-report.mjs",
   "scripts/check-operator.mjs",
   "scripts/update-operator-live-status.mjs"
 ]);

--- a/scripts/operator-heartbeat-daemon.mjs
+++ b/scripts/operator-heartbeat-daemon.mjs
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const args = process.argv.slice(2);
+
+function readArg(name, fallback = "") {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1) return fallback;
+  return args[index + 1] ?? fallback;
+}
+
+function ensureDir(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const writeHeartbeatScript = path.join(scriptDir, "write-operator-heartbeat.mjs");
+const heartbeatPath = readArg("heartbeat", ".omx/state/operator-heartbeat.json");
+const reportPath = readArg("report", "reports/operations/operator-heartbeat-daemon.jsonl");
+const intervalSeconds = Math.max(1, Number(readArg("interval-seconds", "300")));
+const maxHeartbeats = Math.max(0, Number(readArg("max-heartbeats", "0")));
+const pidFile = readArg("pid-file", ".omx/state/operator-heartbeat-daemon.pid");
+const summaryPath = readArg("summary", ".omx/state/operator-heartbeat-daemon-summary.json");
+const issue = readArg("issue", "");
+const item = readArg("item", "");
+const phase = readArg("phase", "heartbeat-daemon");
+const context = readArg("context", "");
+const commandPrefix = readArg("command", "daemon heartbeat");
+const nextAction = readArg("next", "continue supervised operator run");
+const status = readArg("status", "running");
+
+let count = 0;
+const startedAt = new Date().toISOString();
+
+function writeSummary(currentStatus) {
+  ensureDir(summaryPath);
+  fs.writeFileSync(summaryPath, `${JSON.stringify({
+    ok: currentStatus === "completed" || currentStatus === "running",
+    status: currentStatus,
+    started_at: startedAt,
+    updated_at: new Date().toISOString(),
+    pid: process.pid,
+    heartbeat_path: heartbeatPath,
+    report_path: reportPath,
+    interval_seconds: intervalSeconds,
+    max_heartbeats: maxHeartbeats,
+    observed_heartbeats: count,
+    issue,
+    item
+  }, null, 2)}\n`);
+}
+
+function writeHeartbeat() {
+  count += 1;
+  execFileSync(process.execPath, [
+    writeHeartbeatScript,
+    "--heartbeat", heartbeatPath,
+    "--report", reportPath,
+    "--phase", phase,
+    "--iteration", String(count),
+    "--issue", issue,
+    "--item", item,
+    "--command", `${commandPrefix} ${count}`,
+    "--next", nextAction,
+    "--context", context,
+    "--status", status
+  ], { stdio: ["ignore", "ignore", "inherit"] });
+  writeSummary("running");
+}
+
+ensureDir(pidFile);
+fs.writeFileSync(pidFile, `${process.pid}\n`);
+writeSummary("running");
+writeHeartbeat();
+
+if (maxHeartbeats === 1) {
+  writeSummary("completed");
+  process.exit(0);
+}
+
+const timer = setInterval(() => {
+  writeHeartbeat();
+  if (maxHeartbeats > 0 && count >= maxHeartbeats) {
+    clearInterval(timer);
+    writeSummary("completed");
+    process.exit(0);
+  }
+}, intervalSeconds * 1000);
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.on(signal, () => {
+    clearInterval(timer);
+    writeSummary("stopped");
+    process.exit(0);
+  });
+}

--- a/scripts/operator-trial-dry-run.mjs
+++ b/scripts/operator-trial-dry-run.mjs
@@ -19,13 +19,18 @@ function table(headers, rows) {
 
 const scenarioPath = readArg("scenario", "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json");
 const outputPath = readArg("output", "reports/operations/operator-trial-dry-run-20260428.md");
+const maxGapSeconds = Number(readArg("max-gap-seconds", "600"));
 const scenario = JSON.parse(fs.readFileSync(scenarioPath, "utf8"));
 const heartbeatExpected = scenario.heartbeat_windows.reduce((sum, window) => sum + Number(window.expected ?? 0), 0);
 const heartbeatObserved = scenario.heartbeat_windows.reduce((sum, window) => sum + Number(window.observed ?? 0), 0);
 const heartbeatCoverage = heartbeatExpected === 0 ? 100 : Math.round((heartbeatObserved / heartbeatExpected) * 100);
+const staleGapWindows = scenario.heartbeat_windows.filter((window) => {
+  const maxGap = Number(window.max_gap_seconds ?? 0);
+  return maxGap > maxGapSeconds || String(window.freshness ?? "").includes("stale");
+});
 const unresolvedFailures = scenario.failures.filter((failure) => !String(failure.result ?? "").includes("reported"));
 const ciReady = scenario.ci_status.every((check) => ["expected-pass-after-pr", "pass", "success"].includes(check.result));
-const status = heartbeatObserved >= heartbeatExpected && unresolvedFailures.length === 0 && ciReady ? "dry-run-pass" : "dry-run-review";
+const status = heartbeatObserved >= heartbeatExpected && staleGapWindows.length === 0 && unresolvedFailures.length === 0 && ciReady ? "dry-run-pass" : "dry-run-review";
 
 const report = `# Operator Trial Dry Run - ${scenario.trial_id}
 
@@ -47,8 +52,10 @@ Scope-risk: moderate
 - Expected heartbeat count: ${heartbeatExpected}
 - Observed heartbeat count: ${heartbeatObserved}
 - Coverage: ${heartbeatCoverage}%
+- Max allowed gap seconds: ${maxGapSeconds}
+- Stale gap windows: ${staleGapWindows.length}
 
-${table(["Window", "Expected", "Observed", "Freshness", "Evidence"], scenario.heartbeat_windows.map((window) => [window.window, window.expected, window.observed, window.freshness, window.evidence]))}
+${table(["Window", "Expected", "Observed", "Max gap seconds", "Freshness", "Evidence"], scenario.heartbeat_windows.map((window) => [window.window, window.expected, window.observed, window.max_gap_seconds ?? "unknown", window.freshness, window.evidence]))}
 
 ## Completed work
 
@@ -74,6 +81,6 @@ ${scenario.next_queue.map((item) => `- ${item}`).join("\n")}
 fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 fs.writeFileSync(outputPath, report);
 
-console.log(JSON.stringify({ ok: status === "dry-run-pass", status, output: outputPath, heartbeatExpected, heartbeatObserved, heartbeatCoverage, unresolvedFailures: unresolvedFailures.length }, null, 2));
+console.log(JSON.stringify({ ok: status === "dry-run-pass", status, output: outputPath, heartbeatExpected, heartbeatObserved, heartbeatCoverage, maxGapSeconds, staleGapWindows: staleGapWindows.length, unresolvedFailures: unresolvedFailures.length }, null, 2));
 
 if (status !== "dry-run-pass") process.exit(1);

--- a/scripts/operator-watchdog.mjs
+++ b/scripts/operator-watchdog.mjs
@@ -66,10 +66,46 @@ ${result.recovery_next_action}
   fs.writeFileSync(filePath, report);
 }
 
+function writeStuckReport(filePath, result) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const report = `# Operator Watchdog Stuck Report - ${result.checked_at}
+
+Status: reported
+Reason: ${result.reason}
+Scope-risk: narrow
+
+## 감지 신호
+
+- Heartbeat path: \`${result.heartbeat_path}\`
+- Last heartbeat: ${result.heartbeat?.timestamp ?? "unknown"}
+- Branch: ${result.heartbeat?.branch ?? "unknown"}
+- Issue: ${result.heartbeat?.issue ?? "unknown"}
+- PR: ${result.heartbeat?.pr ?? "unknown"}
+- Current command: ${result.heartbeat?.current_command ?? "unknown"}
+- Next action: ${result.heartbeat?.next_action ?? "unknown"}
+- Age seconds: ${result.age_seconds ?? "unknown"}
+- Max age seconds: ${result.max_age_seconds}
+
+## 표준 복구 절차
+
+1. 현재 명령이나 CI 대기가 실제로 살아 있는지 확인한다.
+2. 마지막 heartbeat 이후의 PR/CI 상태를 확인한다.
+3. red/pending CI를 완료로 부르지 않고 repair 또는 blocker report로 분류한다.
+4. 같은 stale class가 3회 이상 반복되면 장시간 run을 중단하고 follow-up issue로 분리한다.
+5. credential, 결제, 외부 배포, 고객 데이터가 필요하면 즉시 escalation한다.
+
+## Recovery next action
+
+${result.recovery_next_action}
+`;
+  fs.writeFileSync(filePath, report);
+}
+
 const heartbeatPath = readArg("heartbeat", ".omx/state/operator-heartbeat.json");
 const maxAgeSeconds = Number(readArg("max-age-seconds", "600"));
 const checkedAt = readArg("now", new Date().toISOString());
-const output = readArg("output", "");
+const output = readArg("output", readArg("report", ""));
+const stuckOutput = readArg("stuck-output", "");
 const { heartbeat, error } = readHeartbeat(heartbeatPath);
 const checkedTime = Date.parse(checkedAt);
 const heartbeatTime = heartbeat?.timestamp ? Date.parse(heartbeat.timestamp) : Number.NaN;
@@ -101,6 +137,7 @@ const result = {
 };
 
 if (output) writeReport(output, result);
+if (stuckOutput && status !== "fresh") writeStuckReport(stuckOutput, result);
 
 console.log(JSON.stringify(result, null, 2));
 


### PR DESCRIPTION
## 요약

- Issue #53의 4h trial에서 발견된 702.5초 heartbeat gap을 Issue #84 follow-up으로 보강합니다.
- 독립 heartbeat daemon runner를 추가해 장시간 PR/CI wait 중에도 foreground agent loop와 분리된 liveness signal을 남길 수 있게 했습니다.
- `operator-trial-dry-run`에 `max_gap_seconds` guard를 추가해 600초 초과 gap fixture를 `dry-run-review` / non-zero로 분류합니다.
- watchdog에 `--stuck-output`을 추가해 stale heartbeat를 자동 stuck report로 남기게 했습니다.

## 검증

- `npm run operator:trial:dry-run` PASS
- `npm run operator:trial:gap-guard` PASS
- `npm run operator:watchdog:stuck-guard` PASS
- `npm run check:operator` PASS
- `npm run check:all` PASS
- Architect verification: APPROVED
- Changed-files-only deslop pass: PASS

## 안전 범위

- 운영 스크립트/문서/fixture/report 변경만 포함
- credentials/customer data/payment/login/ads/external deployment/real GTM 없음
- `ENABLE_AGENT_AUTOMERGE` 변경 없음
- branch protection 우회 없음

Closes #84
