### PR TITLE
Agent Ops: add operator control room and playable mode

### DIFF
--- a/.github/ISSUE_TEMPLATE/agent-work-item.md
+++ b/.github/ISSUE_TEMPLATE/agent-work-item.md
@@ -1,0 +1,46 @@
+---
+name: Agent work item / 에이전트 작업
+about: 에이전트가 수행할 small win 중심 작업을 정의합니다.
+title: ""
+labels: ""
+assignees: ""
+---
+
+## 문제 / 배경
+
+
+## 목표
+
+
+## Small win
+
+- 이번 issue가 만들 가장 작은 승리:
+
+## 플레이어 가치 또는 운영사 가치
+
+- 게임 가치:
+- 운영사 가치:
+
+## 수용 기준
+
+- [ ]
+
+## Visual evidence 계획
+
+- Before screenshot:
+- After screenshot:
+- N/A 사유:
+
+## Playable mode 영향
+
+- [ ] 사람이 `npm run play:main`으로 main 게임을 계속 실행할 수 있다.
+- 변경 확인 URL/port:
+
+## 안전 범위
+
+- 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음.
+- Branch protection 우회 없음.
+
+## 검증 명령
+
+- `npm run check:all`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## 요약
+
+
+## Small win
+
+- 이번 PR이 만든 가장 작은 승리:
+
+## 사용자/운영자 가치
+
+- 게임 가치:
+- 운영사 가치:
+
+## Before / After 또는 Visual evidence
+
+- Before:
+- After:
+- N/A 사유:
+
+## Playable mode
+
+- main 실행 명령: `npm run play:main` 후 필요 시 `npm run play:main:install`, 그리고 `cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174`
+- 이 PR이 사람 플레이 환경을 막지 않는 이유:
+
+## 검증
+
+- [ ] `npm run check:all` PASS
+
+## 안전 범위
+
+- [ ] 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음
+- [ ] `ENABLE_AGENT_AUTOMERGE` 변경 없음
+- [ ] Branch protection 우회 없음
+
+## 남은 위험
+
+
+## 연결된 issue
+
+Closes #

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -25,6 +25,8 @@ Updated: 2026-04-28
 | 운영사 watchdog | review | `npm run operator:watchdog` |
 | 운영사 trial dry-run | review | `npm run operator:trial:dry-run` |
 | 운영사 2h readiness | review | `npm run operator:trial:readiness` |
+| 운영 상황판 | review | `docs/OPERATOR_CONTROL_ROOM.md`, `npm run check:control-room` |
+| 사람 플레이 모드 | verified | `npm run play:main`, port 5174 |
 | Sprite batch QA gate | review | `npm run check:sprite-batch` |
 | 플레이테스트 intake | review | `npm run check:playtest-intake` |
 | GTM mock lane | review | `npm run check:gtm-mock` |
@@ -35,15 +37,15 @@ Updated: 2026-04-28
 | 상태 | 개수 |
 | --- | ---: |
 | done | 29 |
-| review | 60 |
+| review | 61 |
 | todo | 2 |
 | blocked | 0 |
 
 ## 다음 작업
 
-1. 다음 게임 기능 작업을 `items/` 단위로 등록한다.
-2. Branch protection 사용 가능 조건이 바뀌면 required checks 설정을 별도 승인으로 진행한다.
-3. PR check URL까지 포함하는 audit 확장을 검토한다.
+1. `docs/OPERATOR_CONTROL_ROOM.md`에서 active mission/small win/evidence/playable mode를 먼저 확인한다.
+2. 사람이 게임을 확인해야 하면 `npm run play:main` 후 `../strange-seed-shop-play`에서 port 5174로 실행한다.
+3. 24h dry run은 control room/playable mode PR이 merge되고 main CI가 green이 된 뒤 시작한다.
 
 ## 검증 상태
 
@@ -60,6 +62,7 @@ Updated: 2026-04-28
 | `npm run check:asset-normalization` | tracked |
 | `npm run check:playtest-intake` | tracked |
 | `npm run check:gtm-mock` | tracked |
+| `npm run check:control-room` | tracked |
 | `npm run check:operator` | tracked |
 | `npm run check:governance` | tracked |
 | `npm run check:audit` | tracked |
@@ -70,3 +73,4 @@ Updated: 2026-04-28
 - `main` Branch protection은 2026-04-28 기준 활성이고 required checks를 강제한다. `ENABLE_AGENT_AUTOMERGE` 활성화는 별도 운영 결정으로 유지한다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.
+- 운영 상황판은 살아있는 snapshot이므로 장시간 run 시작/종료/PR 전후에 `npm run operator:control-room -- --output reports/operations/operator-control-room-YYYYMMDD.md`로 갱신한다.

--- a/docs/OPERATOR_CONTROL_ROOM.md
+++ b/docs/OPERATOR_CONTROL_ROOM.md
@@ -1,0 +1,124 @@
+# Operator Control Room / 운영 상황판
+
+Status: v0-control-room
+Owner: agent
+Last updated: 2026-04-28
+Applies to: 모든 장시간 `$ralph`, issue-to-PR loop, 24h dry run 전 운영
+
+## 왜 필요한가
+
+4h trial은 자동화가 실제로 issue → branch → PR → CI → merge → report를 반복할 수 있음을 증명했다. 하지만 사람이 중간에 돌아왔을 때 “지금 무엇을, 왜, 어디까지 했는지”를 한눈에 보기 어려웠다. 이 문서는 자동화의 속도를 유지하면서도 사람이 언제든 이해·검수·플레이할 수 있게 만드는 control room 계약이다.
+
+## 한눈에 보는 현재 미션
+
+| 필드 | 현재 값 |
+| --- | --- |
+| 운영 북극성 | 에이전트가 안전하게 오래 일하되, 사람이 즉시 이해하고 멈출 수 있는 게임 스튜디오 |
+| 게임 북극성 | 첫 5분 안에 “귀엽다, 하나만 더 키우자”를 만드는 수집 idle game |
+| 현재 milestone | 24h dry run 전 운영 가시성 보강 |
+| Active issue | #87 — Operator Control Room + Playable Mode |
+| Active branch | `codex/operator-control-room` |
+| 이번 small win | 사람이 퇴근/복귀/중간 확인 시 현재 작업·결과·증거·게임 실행법을 한 화면에서 파악한다 |
+| 플레이어 가치 | 자동화가 UI/게임을 계속 바꿔도 사람은 main 기준 게임을 열고 재미/귀여움/혼란을 직접 확인할 수 있다 |
+| 다음 안전 정지점 | PR green + main CI green + `npm run check:all` PASS |
+| 24h dry run gate | 이 control room PR이 merge되기 전 24h dry run 금지 |
+
+## Control Room 카드 형식
+
+모든 active mission은 아래 필드를 가져야 한다.
+
+| 필드 | 설명 |
+| --- | --- |
+| Mission | 사람이 읽는 한 줄 목표 |
+| Milestone | `docs/ROADMAP.md`의 어느 단계인지 |
+| Issue / PR | GitHub issue, draft PR, merge PR 링크 |
+| Small win | 이번 PR이 만드는 가장 작은 승리 |
+| Why it matters | 게임 북극성 또는 운영사 북극성과의 연결 |
+| Phase | planning / implementing / verifying / PR / merged / blocked |
+| Evidence | 테스트, CI, report, screenshot 링크 |
+| Visual delta | before/after screenshot 또는 `N/A — 이유` |
+| Playable status | main 게임 실행 가능 여부와 명령 |
+| Next safe stop | 사람이 멈춰도 되는 다음 지점 |
+| Next queue | 이 작업 이후의 안전한 다음 작업 |
+
+## Issue 작성 규칙
+
+Issue는 한국어 우선으로 작성하고, 다음 섹션을 포함한다.
+
+1. 문제 / 배경
+2. 목표
+3. Small win
+4. 플레이어 가치 또는 운영사 가치
+5. 수용 기준
+6. Visual evidence 계획
+7. Playable mode 영향
+8. 안전 범위
+9. 검증 명령
+
+## PR 작성 규칙
+
+PR은 사람이 60초 안에 리뷰 방향을 잡을 수 있어야 한다.
+
+필수 섹션:
+
+- 요약
+- Small win
+- 사용자/운영자 가치
+- Before / After 또는 Visual evidence
+- Playable mode
+- 검증
+- 안전 범위
+- 남은 위험
+- 연결된 issue
+
+UI/게임 변경 PR은 `reports/visual/`의 before/after screenshot을 연결한다. 문서·스크립트만 바꾸는 PR은 `N/A — UI 변화 없음`처럼 이유를 쓴다.
+
+## Playable Mode / 사람 플레이 가능 모드
+
+Agent가 feature branch에서 장시간 작업 중이어도 사람은 main 기준 게임을 별도 worktree로 실행한다.
+
+권장 명령:
+
+```bash
+npm run play:main
+# dependencies가 없으면 한 번만:
+npm run play:main:install
+cd ../strange-seed-shop-play
+npm run dev -- --host 127.0.0.1 --port 5174
+```
+
+원칙:
+
+- agent 작업 branch와 사람 플레이 branch를 분리한다.
+- 사람 플레이용 worktree는 `origin/main` detached 상태를 기본으로 한다.
+- 기본 포트는 agent dev server와 충돌을 피하기 위해 `5174`를 쓴다.
+- 플레이용 worktree가 dirty이면 script는 기본적으로 멈추고 덮어쓰지 않는다.
+- 사람이 플레이 중이면 agent는 같은 port를 점유하지 않는다.
+
+## Visual evidence 계약
+
+| 변경 유형 | Evidence |
+| --- | --- |
+| 게임 UI/UX | mobile 360px after screenshot + 가능하면 before screenshot |
+| desktop 영향 | desktop 1280px screenshot |
+| Phaser/playfield | Browser Use 우선, 차단 시 CDP fallback 이유와 screenshot |
+| 문서/운영 스크립트 | `N/A — UI 변화 없음`, 대신 report/check output |
+| Playable mode | 실행 명령과 port/worktree 상태 |
+
+## 운영 리듬
+
+1. Issue 생성: small win과 visual/playable 계획 포함.
+2. Branch 시작: heartbeat와 control room snapshot 기록.
+3. 구현: 작은 단위로 변경.
+4. 검증: local checks + visual/playable evidence.
+5. Draft PR: control room 형식의 PR 본문.
+6. Ready/merge: required checks 통과 후 branch protection 우회 없이 merge.
+7. Main 확인: main CI + local `npm run check:all`.
+8. Dashboard/roadmap 갱신: 다음 safe queue를 명시.
+
+## 관련 리서치에서 가져온 원칙
+
+- ClawSweeper: dashboard는 장식이 아니라 queue/review/apply/audit health를 보여주는 운영 표면이다.
+- GitHub Mission Control: agent task는 한 곳에서 시작·추적·PR jump가 가능해야 한다.
+- Ralph 계열: phase isolation, progress file, stale recovery가 없으면 “계속 도는 loop”가 사람에게 불투명해진다.
+- Agentic PR 연구: 작은 작업, green CI, reviewer engagement, 명확한 scope가 merge 가능성을 높인다.

--- a/docs/PLAYABLE_MODE.md
+++ b/docs/PLAYABLE_MODE.md
@@ -1,0 +1,60 @@
+# Playable Mode / 사람 플레이 모드
+
+Status: v0
+Owner: agent
+Last updated: 2026-04-28
+
+## 목적
+
+Agent가 장시간 feature branch에서 작업 중이어도 사람은 언제든 안정적인 `main` 기준 게임을 실행하고 직접 확인할 수 있어야 한다.
+
+## 빠른 실행
+
+```bash
+npm run play:main
+# dependencies가 없으면 한 번만:
+npm run play:main:install
+cd ../strange-seed-shop-play
+npm run dev -- --host 127.0.0.1 --port 5174
+```
+
+브라우저에서 `http://127.0.0.1:5174`를 연다.
+
+## 작동 방식
+
+`npm run play:main`은 sibling worktree `../strange-seed-shop-play`를 준비한다.
+
+- 기준: `origin/main`
+- checkout 방식: detached HEAD
+- 기본 포트: `5174`
+- 목적: agent 작업 branch와 사람 플레이 환경 분리
+
+## 안전 규칙
+
+- 기존 플레이용 worktree가 dirty이면 기본 동작은 중단이다.
+- 강제 초기화는 `--force`를 명시적으로 줄 때만 허용한다.
+- dependency install은 자동으로 하지 않는다. 필요하면 플레이용 worktree 안에서 `npm install` 또는 `npm ci`를 실행한다.
+- agent는 사람이 플레이 중인 port `5174`를 사용하지 않는다.
+
+## 명령 옵션
+
+```bash
+node scripts/prepare-playable-main.mjs --path ../strange-seed-shop-play --port 5174
+node scripts/prepare-playable-main.mjs --check
+node scripts/prepare-playable-main.mjs --install
+node scripts/prepare-playable-main.mjs --serve
+```
+
+- `--check`: worktree를 만들지 않고 계약과 출력만 검증한다.
+- `--serve`: 준비 후 플레이용 worktree에서 dev server를 실행한다.
+- `--force`: dirty 플레이용 worktree를 `origin/main`으로 되돌린다. 사람 작업이 날아갈 수 있으므로 기본 금지다.
+
+## PR/Issue에 남길 내용
+
+UI/게임 변경 PR은 다음을 남긴다.
+
+- main playable command
+- after screenshot 링크
+- before screenshot 또는 N/A 사유
+- 확인 viewport
+- 사람이 직접 확인할 URL/port

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,8 @@ This folder is the durable memory for `이상한 씨앗상회` and the agent-nat
 | `SESSION_HANDOFF_20260427.md` | 이번 세션의 작업 맥락과 다음 deep interview 시작점 | Before starting a new session |
 | `AUTONOMOUS_PROJECT_OPERATING_MODEL.md` | ClawSweeper-inspired agent operating model | Before automation/project-management work |
 | `OPERATOR_RUNBOOK.md` | 장시간 `$ralph` 운영사의 start, monitor, recover, stop, summarize 절차 | Before supervised 4h/24h operator runs |
+| `OPERATOR_CONTROL_ROOM.md` | 사람이 현재 mission, small win, evidence, playable mode를 한눈에 보는 운영 상황판 | Before/while running autonomous sessions |
+| `PLAYABLE_MODE.md` | Agent 작업 중에도 사람이 `main` 게임을 별도 worktree/port로 실행하는 절차 | Before manual playtesting during agent work |
 | `BROWSER_QA.md` | Browser Use 기반 로컬 브라우저 검증 절차 | Before visual/mobile QA |
 | `PR_AUTOMATION.md` | PR 자동 검증과 제한적 자동 머지 정책 | Before CI/PR automation work |
 | `AUTOMERGE_GOVERNANCE.md` | 자동 머지 활성화 전 Branch protection과 변수 운영 조건 | Before changing GitHub merge settings |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -181,6 +181,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Add live operator status report | review | `scripts/update-operator-live-status.mjs`, `reports/operations/operator-live-status-20260428.md`, `items/0040-operator-live-status-report.md` | Running trial의 heartbeat freshness, deadline, completed PRs, recovery, next action을 한 파일로 생성하고 `check:operator`가 검증함 |
 | Run 4-hour supervised trial | review | `reports/operations/operator-trial-20260428T053230Z.md`, `items/0035-supervised-4h-operator-trial.md` | heartbeat 47건, merge된 PR 15개, green main CI, initial stuck report, final watchdog freshness, heartbeat gap warning이 기록됨 |
 | Harden heartbeat daemon before 24h run | review | Issue #84, `scripts/operator-heartbeat-daemon.mjs`, `reports/operations/heartbeat-daemon-hardening-20260428.md`, `items/0051-heartbeat-daemon-hardening.md` | 독립 heartbeat daemon, stale-gap dry-run guard, watchdog stuck-output guard로 600초 초과 gap을 완료로 오인하지 않게 한다 |
+| Add operator control room and playable mode | review | Issue #87, `docs/OPERATOR_CONTROL_ROOM.md`, `docs/PLAYABLE_MODE.md`, `.github/ISSUE_TEMPLATE/agent-work-item.md`, `.github/pull_request_template.md`, `scripts/prepare-playable-main.mjs`, `items/0052-operator-control-room-playable-mode.md` | 사람이 active mission, small win, visual evidence, PR/issue, playable main command를 한 화면에서 파악하고 agent 작업 중에도 게임을 실행할 수 있음 |
 
 ## Milestone 8: Feedback + GTM Mock Intake
 
@@ -206,7 +207,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report는 PR #85로 merge되어 닫혔고, 현재 안전한 다음 작업은 Issue #84의 heartbeat daemon hardening을 PR로 검증·merge하는 것이다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report와 Issue #84 heartbeat daemon hardening은 merge 완료되었다. 현재 안전한 다음 작업은 Issue #87의 operator control room + playable mode를 PR로 검증·merge해 사람이 자동화 중에도 현재 mission과 게임 실행 상태를 즉시 파악하게 하는 것이다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.
@@ -241,3 +242,4 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 31. Issue #82 / PR #83은 merge 완료되어 하단 원정 탭에 진행/완료 배지를 붙여 다른 탭에서도 복귀·수령 신호를 놓치지 않게 한다.
 32. Issue #53의 4h supervised trial report는 `reports/operations/operator-trial-20260428T053230Z.md`로 작성되었고, PR #85로 merge되어 닫혔다.
 33. Issue #84는 24h run 전 heartbeat daemon hardening 작업으로, 4h trial에서 드러난 702.5초 gap을 dry-run failure와 watchdog stuck report로 고정한다.
+34. Issue #87은 24h dry run 전 operator control room과 playable mode를 고정해 사람이 중간에 현재 mission, small win, evidence, 게임 실행법을 즉시 파악하게 한다.

--- a/items/0052-operator-control-room-playable-mode.md
+++ b/items/0052-operator-control-room-playable-mode.md
@@ -1,0 +1,47 @@
+# Operator control room and playable mode
+
+Status: review
+Owner: agent
+Created: 2026-04-28
+Updated: 2026-04-28
+Scope-risk: moderate
+Work type: agent_ops
+Issue: #87
+Branch: codex/operator-control-room
+
+## Intent
+
+4h trial과 heartbeat hardening은 자동화가 실제로 잘 돌아감을 보여줬지만, 사람이 중간에 현재 목표·small win·결과·스크린샷·게임 실행 방법을 한눈에 보기 어려웠다. 24h dry run 전에 운영 상황판과 사람 플레이 모드를 고정한다.
+
+## Acceptance Criteria
+
+- `docs/OPERATOR_CONTROL_ROOM.md`가 active mission, small win, evidence, visual delta, playable status, next safe stop을 정의한다.
+- issue/PR 템플릿에 한국어 우선 small win, visual evidence, playable mode 섹션이 있다.
+- `docs/PLAYABLE_MODE.md`와 `npm run play:main`이 agent branch와 분리된 `origin/main` worktree 실행 방법을 제공한다.
+- `npm run operator:control-room`이 현재 local/GitHub 상태와 playable mode 명령을 출력한다.
+- `npm run check:control-room`, `npm run check:operator`, `npm run check:all`이 통과한다.
+- 24h dry run은 이 작업이 merge되기 전 시작하지 않는다.
+
+## Evidence
+
+- Issue #87: https://github.com/bborok1234/strange-seed-shop/issues/87
+- Control room: `docs/OPERATOR_CONTROL_ROOM.md`
+- Playable mode: `docs/PLAYABLE_MODE.md`
+- Research note: `reports/research/agent_operator_control_room_research_20260428.md`
+- Templates: `.github/ISSUE_TEMPLATE/agent-work-item.md`, `.github/pull_request_template.md`
+- Scripts: `scripts/operator-control-room.mjs`, `scripts/prepare-playable-main.mjs`, `scripts/check-operator-control-room.mjs`
+
+## Apply Conditions
+
+- 실제 고객 데이터, credential, 결제, 로그인/account, ads SDK, external deployment, 실채널 GTM을 건드리지 않는다.
+- `ENABLE_AGENT_AUTOMERGE`를 켜지 않는다.
+- Branch protection과 required checks를 우회하지 않는다.
+- UI 변화가 없으면 visual evidence는 `N/A — UI 변화 없음`으로 기록한다.
+
+## Verification
+
+- `npm run check:control-room`
+- `npm run operator:control-room -- --output reports/operations/operator-control-room-20260428.md`
+- `npm run check:operator`
+- `npm run check:all`
+- Playable mode smoke: `npm run play:main:install`, Vite on `127.0.0.1:5174`, HTTP GET `/` PASS

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check:governance": "node scripts/check-governance.mjs",
     "update:pr-audit": "node scripts/update-pr-automation-audit.mjs",
     "check:audit": "node scripts/check-audit-reports.mjs",
-    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:browser-qa && npm run check:sprite-batch && npm run check:asset-normalization && npm run check:playtest-intake && npm run check:gtm-mock && npm run operator:trial:gap-guard && npm run operator:watchdog:stuck-guard && npm run check:operator && npm run check:governance && npm run check:audit && npm run build",
+    "check:all": "npm run check:content && npm run check:loop && npm run simulate:economy && npm run check:docs && npm run check:apply && npm run check:dashboard && npm run check:browser-qa && npm run check:sprite-batch && npm run check:asset-normalization && npm run check:playtest-intake && npm run check:gtm-mock && npm run check:control-room && npm run operator:trial:gap-guard && npm run operator:watchdog:stuck-guard && npm run check:operator && npm run check:governance && npm run check:audit && npm run build",
     "check:sprite-batch": "node scripts/check-sprite-batch.mjs",
     "check:operator": "node scripts/check-operator.mjs",
     "operator:watchdog": "node scripts/operator-watchdog.mjs",
@@ -32,7 +32,12 @@
     "operator:live-status": "node scripts/update-operator-live-status.mjs --output reports/operations/operator-live-status-20260428.md",
     "operator:heartbeat:daemon": "node scripts/operator-heartbeat-daemon.mjs",
     "operator:trial:gap-guard": "node scripts/check-operator-trial-gap-guard.mjs",
-    "operator:watchdog:stuck-guard": "node scripts/check-operator-watchdog-stuck-report.mjs"
+    "operator:watchdog:stuck-guard": "node scripts/check-operator-watchdog-stuck-report.mjs",
+    "operator:control-room": "node scripts/operator-control-room.mjs",
+    "play:main": "node scripts/prepare-playable-main.mjs",
+    "check:control-room": "node scripts/check-operator-control-room.mjs && node scripts/prepare-playable-main.mjs --check",
+    "play:main:install": "node scripts/prepare-playable-main.mjs --install",
+    "play:main:serve": "node scripts/prepare-playable-main.mjs --install --serve"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^5.0.0",

--- a/reports/operations/operator-control-room-20260428.md
+++ b/reports/operations/operator-control-room-20260428.md
@@ -1,0 +1,42 @@
+# Operator Control Room Snapshot
+
+Generated at: 2026-04-28T12:09:37.128Z
+
+## Current mission
+
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report와 Issue #84 heartbeat daemon hardening은 merge 완료되었다. 현재 안전한 다음 작업은 Issue #87의 operator control room + playable mode를 PR로 검증·merge해 사람이 자동화 중에도 현재 mission과 게임 실행 상태를 즉시 파악하게 하는 것이다.
+
+## Local state
+
+- Branch: codex/operator-control-room
+- Latest commit: e2b5564 24시간 운영 전 heartbeat 공백을 실패로 만들기
+- Dirty files: present
+
+## Open PRs
+
+- unavailable or none
+
+## Open issues
+
+- #87 Agent Ops: add operator control room and playable mode — https://github.com/bborok1234/strange-seed-shop/issues/87
+
+## Playable mode
+
+- Prepare stable main worktree: `npm run play:main`
+- Serve stable main game: `cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174`
+- URL: http://127.0.0.1:5174
+
+## Visual evidence rule
+
+- UI/game PR: link before/after screenshots under `reports/visual/`.
+- Docs/scripts-only PR: write `N/A — UI 변화 없음` and link check output/report.
+
+## Next safe stop
+
+Stop only after PR required checks, main CI, and local `npm run check:all` are green, or after a written blocker report.
+
+## Playable mode smoke proof
+
+- `npm run play:main:install` PASS — `../strange-seed-shop-play` prepared as detached `origin/main` worktree and dependencies installed.
+- Temporary Vite server on `http://127.0.0.1:5174/` returned index HTML (`614` bytes).
+- Server was stopped after smoke verification; no long-running play server remains.

--- a/reports/research/agent_operator_control_room_research_20260428.md
+++ b/reports/research/agent_operator_control_room_research_20260428.md
@@ -1,0 +1,31 @@
+# Agent Operator Control Room Research — 2026-04-28
+
+Status: reference
+Issue: #87
+
+## 조사 대상
+
+- ClawSweeper: https://github.com/openclaw/clawsweeper
+- ClawSweeper guide: https://clawsweeper.click/
+- GitHub Copilot Agents panel / Mission Control: https://github.blog/news-insights/product-news/agents-panel-launch-copilot-coding-agent-tasks-anywhere-on-github/
+- GitHub Copilot cloud agent docs: https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent
+- Wiggum Ralph loop: https://wiggum.app/blog/what-is-the-ralph-loop/
+- iannuttall/ralph: https://github.com/iannuttall/ralph
+- Ralphy: https://ralphy.goshen.fyi/
+- AIWG issue-driven/external Ralph: https://github.com/jmagly/aiwg
+- Agentic PR studies: arXiv 2509.14745, 2601.15195, 2602.08915
+
+## 핵심 발견
+
+1. ClawSweeper는 dashboard를 queue/review/apply/audit health를 보여주는 운영 표면으로 사용한다.
+2. GitHub Mission Control은 task 시작, 진행 상태, session logs, PR jump를 한 곳에 둔다.
+3. Ralph 계열은 파일/git 상태를 memory로 삼고, phase isolation과 stale recovery를 중요하게 둔다.
+4. Agentic PR 연구는 작은 scope, green CI, 명확한 reviewer engagement가 중요하다고 시사한다.
+5. 우리 repo에는 자동 실행 증거는 늘었지만, 사람이 보는 mission board와 playable mode가 부족하다.
+
+## 적용 결정
+
+- `docs/OPERATOR_CONTROL_ROOM.md`를 living contract로 둔다.
+- issue/PR 템플릿에 small win, visual evidence, playable mode를 필수화한다.
+- `npm run play:main`으로 사람 플레이용 detached `origin/main` worktree를 만든다. Playable mode는 agent branch와 사람 검수 환경을 분리하는 필수 운영 표면이다.
+- `npm run check:control-room`으로 control room/템플릿/playable mode 계약을 검증한다.

--- a/scripts/check-docs-index.mjs
+++ b/scripts/check-docs-index.mjs
@@ -12,6 +12,8 @@ const requiredDocs = [
   "docs/SESSION_HANDOFF_20260427.md",
   "docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md",
   "docs/OPERATOR_RUNBOOK.md",
+  "docs/OPERATOR_CONTROL_ROOM.md",
+  "docs/PLAYABLE_MODE.md",
   "docs/BROWSER_QA.md",
   "docs/PR_AUTOMATION.md",
   "docs/AUTOMERGE_GOVERNANCE.md",

--- a/scripts/check-operator-control-room.mjs
+++ b/scripts/check-operator-control-room.mjs
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+
+const failures = [];
+
+function requirePath(filePath) {
+  if (!fs.existsSync(filePath)) failures.push(`missing required path: ${filePath}`);
+}
+
+function requirePhrases(filePath, phrases) {
+  if (!fs.existsSync(filePath)) return;
+  const content = fs.readFileSync(filePath, "utf8");
+  for (const phrase of phrases) {
+    if (!content.includes(phrase)) failures.push(`${filePath} missing phrase: ${phrase}`);
+  }
+}
+
+const requiredPaths = [
+  "docs/OPERATOR_CONTROL_ROOM.md",
+  "docs/PLAYABLE_MODE.md",
+  "reports/research/agent_operator_control_room_research_20260428.md",
+  ".github/ISSUE_TEMPLATE/agent-work-item.md",
+  ".github/pull_request_template.md",
+  "scripts/prepare-playable-main.mjs",
+  "scripts/operator-control-room.mjs"
+];
+
+for (const filePath of requiredPaths) requirePath(filePath);
+
+requirePhrases("docs/OPERATOR_CONTROL_ROOM.md", [
+  "Operator Control Room",
+  "Small win",
+  "Visual evidence",
+  "Playable Mode",
+  "npm run play:main",
+  "5174",
+  "24h dry run gate",
+  "ClawSweeper",
+  "GitHub Mission Control",
+  "Ralph"
+]);
+
+requirePhrases("docs/PLAYABLE_MODE.md", [
+  "사람 플레이 모드",
+  "../strange-seed-shop-play",
+  "detached HEAD",
+  "5174",
+  "--force",
+  "--serve"
+]);
+
+requirePhrases(".github/ISSUE_TEMPLATE/agent-work-item.md", [
+  "Small win",
+  "플레이어 가치 또는 운영사 가치",
+  "Visual evidence 계획",
+  "Playable mode 영향",
+  "npm run play:main"
+]);
+
+requirePhrases(".github/pull_request_template.md", [
+  "Small win",
+  "Before / After 또는 Visual evidence",
+  "Playable mode",
+  "npm run play:main",
+  "남은 위험"
+]);
+
+requirePhrases("scripts/prepare-playable-main.mjs", [
+  "git",
+  "worktree",
+  "--detach",
+  "origin/main",
+  "5174",
+  "--check",
+  "--serve",
+  "--force",
+  "playable worktree has local changes"
+]);
+
+requirePhrases("scripts/operator-control-room.mjs", [
+  "Operator Control Room Snapshot",
+  "Open PRs",
+  "Open issues",
+  "Playable mode",
+  "Visual evidence rule",
+  "Next safe stop"
+]);
+
+console.log(JSON.stringify({ ok: failures.length === 0, requiredPaths: requiredPaths.length, failures }, null, 2));
+if (failures.length > 0) process.exit(1);

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -43,20 +43,28 @@ const requiredPaths = [
   "items/0034-operator-runbook-daily-report.md",
   "items/0040-operator-live-status-report.md",
   "items/0051-heartbeat-daemon-hardening.md",
+  "items/0052-operator-control-room-playable-mode.md",
   "items/0029-operator-completion-gate.md",
   "docs/OPERATOR_RUNBOOK.md",
+  "docs/OPERATOR_CONTROL_ROOM.md",
+  "docs/PLAYABLE_MODE.md",
   "reports/operations/operator-trial-readiness-20260428.md",
   "reports/operations/operator-trial-20260428T025400Z.md",
   "reports/operations/operator-trial-20260428T053230Z.md",
   "reports/operations/daily-template-20260428.md",
   "reports/operations/operator-live-status-20260428.md",
   "reports/operations/heartbeat-daemon-hardening-20260428.md",
+  "reports/operations/operator-control-room-20260428.md",
+  "reports/research/agent_operator_control_room_research_20260428.md",
   "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json",
   "reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json",
   "reports/operations/operator-trial-dry-run-20260428.md",
   "reports/operations/operator-trial-stale-gap-guard-20260428.md",
   "scripts/write-operator-heartbeat.mjs",
   "scripts/operator-heartbeat-daemon.mjs",
+  "scripts/operator-control-room.mjs",
+  "scripts/prepare-playable-main.mjs",
+  "scripts/check-operator-control-room.mjs",
   "scripts/update-operator-live-status.mjs",
   "scripts/operator-trial-dry-run.mjs",
   "scripts/check-operator-trial-gap-guard.mjs",
@@ -66,7 +74,9 @@ const requiredPaths = [
   "scripts/report-operator-stuck.mjs",
   "scripts/check-operator.mjs",
   "docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md",
-  "docs/PR_AUTOMATION.md"
+  "docs/PR_AUTOMATION.md",
+  ".github/ISSUE_TEMPLATE/agent-work-item.md",
+  ".github/pull_request_template.md"
 ];
 
 for (const filePath of requiredPaths) requirePath(filePath);
@@ -182,6 +192,67 @@ requirePhrases("reports/operations/fixtures/operator-trial-stale-gap-scenario-20
   "Issue #84"
 ]);
 
+
+
+requirePhrases("items/0052-operator-control-room-playable-mode.md", [
+  "Status: review",
+  "Work type: agent_ops",
+  "Issue: #87",
+  "small win",
+  "playable mode",
+  "npm run check:control-room",
+  "npm run check:all"
+]);
+
+requirePhrases("docs/OPERATOR_CONTROL_ROOM.md", [
+  "Operator Control Room",
+  "Small win",
+  "Visual evidence",
+  "Playable Mode",
+  "npm run play:main",
+  "5174",
+  "24h dry run gate"
+]);
+
+requirePhrases("docs/PLAYABLE_MODE.md", [
+  "사람 플레이 모드",
+  "../strange-seed-shop-play",
+  "detached HEAD",
+  "5174",
+  "--serve",
+  "--force"
+]);
+
+requirePhrases("reports/operations/operator-control-room-20260428.md", [
+  "Operator Control Room Snapshot",
+  "Current mission",
+  "Open issues",
+  "Playable mode",
+  "Visual evidence rule",
+  "Next safe stop"
+]);
+
+requirePhrases("reports/research/agent_operator_control_room_research_20260428.md", [
+  "ClawSweeper",
+  "GitHub Mission Control",
+  "Ralph",
+  "Playable mode",
+  "small win"
+]);
+
+requirePhrases(".github/ISSUE_TEMPLATE/agent-work-item.md", [
+  "Small win",
+  "Visual evidence 계획",
+  "Playable mode 영향",
+  "npm run play:main"
+]);
+
+requirePhrases(".github/pull_request_template.md", [
+  "Small win",
+  "Before / After 또는 Visual evidence",
+  "Playable mode",
+  "npm run play:main"
+]);
 
 requirePhrases("items/0022-supervised-2h-trial-readiness-gate.md", [
   "Status: in_progress",
@@ -382,11 +453,17 @@ requirePhrases("package.json", [
   "operator:trial:dry-run",
   "operator:trial:gap-guard",
   "operator:watchdog:stuck-guard",
+  "operator:control-room",
+  "play:main",
+  "check:control-room",
   "operator:trial:readiness",
   "operator:live-status",
   "scripts/operator-heartbeat-daemon.mjs",
   "scripts/check-operator-trial-gap-guard.mjs",
   "scripts/check-operator-watchdog-stuck-report.mjs",
+  "scripts/operator-control-room.mjs",
+  "scripts/prepare-playable-main.mjs",
+  "scripts/check-operator-control-room.mjs",
   "scripts/check-operator.mjs",
   "scripts/update-operator-live-status.mjs"
 ]);

--- a/scripts/operator-control-room.mjs
+++ b/scripts/operator-control-room.mjs
@@ -1,0 +1,72 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("--output");
+const outputPath = outputIndex === -1 ? "" : args[outputIndex + 1] ?? "";
+
+function tryRun(command, commandArgs) {
+  try {
+    return execFileSync(command, commandArgs, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+  } catch {
+    return "unavailable";
+  }
+}
+
+function read(filePath, fallback = "") {
+  return fs.existsSync(filePath) ? fs.readFileSync(filePath, "utf8") : fallback;
+}
+
+const roadmap = read("docs/ROADMAP.md");
+const currentNext = roadmap.split("\n").find((line) => line.startsWith("`docs/NORTH_STAR.md`")) ?? "Current Next Action unavailable";
+const branch = tryRun("git", ["branch", "--show-current"]);
+const status = tryRun("git", ["status", "--short"]);
+const latestCommit = tryRun("git", ["log", "-1", "--oneline"]);
+const openPrs = tryRun("gh", ["pr", "list", "--state", "open", "--limit", "5", "--json", "number,title,isDraft,url", "--jq", ".[] | \"#\\(.number) \\(.isDraft // false | if . then \\\"draft\\\" else \\\"ready\\\" end) \\(.title) — \\(.url)\""]);
+const openIssues = tryRun("gh", ["issue", "list", "--state", "open", "--limit", "5", "--json", "number,title,url", "--jq", ".[] | \"#\\(.number) \\(.title) — \\(.url)\""]);
+
+const report = `# Operator Control Room Snapshot
+
+Generated at: ${new Date().toISOString()}
+
+## Current mission
+
+${currentNext}
+
+## Local state
+
+- Branch: ${branch}
+- Latest commit: ${latestCommit}
+- Dirty files: ${status === "" ? "none" : "present"}
+
+## Open PRs
+
+${openPrs === "" || openPrs === "unavailable" ? "- unavailable or none" : openPrs.split("\n").map((line) => `- ${line}`).join("\n")}
+
+## Open issues
+
+${openIssues === "" || openIssues === "unavailable" ? "- unavailable or none" : openIssues.split("\n").map((line) => `- ${line}`).join("\n")}
+
+## Playable mode
+
+- Prepare stable main worktree: \`npm run play:main\`
+- Serve stable main game: \`cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174\`
+- URL: http://127.0.0.1:5174
+
+## Visual evidence rule
+
+- UI/game PR: link before/after screenshots under \`reports/visual/\`.
+- Docs/scripts-only PR: write \`N/A — UI 변화 없음\` and link check output/report.
+
+## Next safe stop
+
+Stop only after PR required checks, main CI, and local \`npm run check:all\` are green, or after a written blocker report.
+`;
+
+if (outputPath) {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, report);
+}
+
+console.log(report);

--- a/scripts/prepare-playable-main.mjs
+++ b/scripts/prepare-playable-main.mjs
@@ -1,0 +1,115 @@
+import { execFileSync, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const args = process.argv.slice(2);
+// Supported flags: --check, --serve, --install, --force
+
+function readArg(name, fallback = "") {
+  const index = args.indexOf(`--${name}`);
+  if (index === -1) return fallback;
+  return args[index + 1] ?? fallback;
+}
+
+function hasFlag(name) {
+  return args.includes(`--${name}`);
+}
+
+function run(command, commandArgs, options = {}) {
+  const output = execFileSync(command, commandArgs, {
+    encoding: "utf8",
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+    cwd: options.cwd ?? process.cwd()
+  });
+  return typeof output === "string" ? output.trim() : "";
+}
+
+function tryRun(command, commandArgs, options = {}) {
+  try {
+    return run(command, commandArgs, options);
+  } catch {
+    return "";
+  }
+}
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"]);
+const targetPath = path.resolve(repoRoot, readArg("path", "../strange-seed-shop-play"));
+const port = readArg("port", "5174");
+const checkOnly = hasFlag("check");
+const serve = hasFlag("serve");
+const force = hasFlag("force");
+const install = hasFlag("install");
+
+function worktreeExists() {
+  return fs.existsSync(path.join(targetPath, "package.json")) && fs.existsSync(path.join(targetPath, ".git"));
+}
+
+function isDirty(cwd) {
+  return tryRun("git", ["status", "--porcelain"], { cwd }).length > 0;
+}
+
+const result = {
+  ok: true,
+  targetPath,
+  port,
+  mode: checkOnly ? "check" : serve ? "prepare-and-serve" : "prepare",
+  checkout: "detached origin/main",
+  commands: [
+    `cd ${targetPath}`,
+    "npm install",
+    `npm run dev -- --host 127.0.0.1 --port ${port}`
+  ],
+  notes: []
+};
+
+if (checkOnly) {
+  result.notes.push("check mode does not create or modify the playable worktree");
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(0);
+}
+
+run("git", ["fetch", "origin", "main"], { cwd: repoRoot });
+
+if (!worktreeExists()) {
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  run("git", ["worktree", "add", "--detach", targetPath, "origin/main"], { cwd: repoRoot, stdio: "inherit" });
+  result.notes.push("created playable worktree from origin/main");
+} else {
+  if (isDirty(targetPath) && !force) {
+    console.error(JSON.stringify({
+      ok: false,
+      targetPath,
+      reason: "playable worktree has local changes; rerun with --force only if you want to discard them"
+    }, null, 2));
+    process.exit(1);
+  }
+
+  run("git", ["checkout", "--detach", "origin/main"], { cwd: targetPath });
+  if (force) run("git", ["reset", "--hard", "origin/main"], { cwd: targetPath, stdio: "inherit" });
+  result.notes.push("refreshed playable worktree to detached origin/main");
+}
+
+const packageJson = path.join(targetPath, "package.json");
+if (!fs.existsSync(packageJson)) {
+  console.error(JSON.stringify({ ok: false, targetPath, reason: "package.json missing after worktree preparation" }, null, 2));
+  process.exit(1);
+}
+
+if (!fs.existsSync(path.join(targetPath, "node_modules"))) {
+  if (install) {
+    run("npm", ["install"], { cwd: targetPath, stdio: "inherit" });
+    result.notes.push("installed dependencies in playable worktree");
+  } else {
+    result.notes.push("node_modules is missing; run npm install inside the playable worktree before serving, or rerun with --install");
+  }
+}
+
+console.log(JSON.stringify(result, null, 2));
+
+if (serve) {
+  const child = spawn("npm", ["run", "dev", "--", "--host", "127.0.0.1", "--port", port], {
+    cwd: targetPath,
+    stdio: "inherit"
+  });
+  child.on("exit", (code) => process.exit(code ?? 0));
+}

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -44,6 +44,8 @@ const rows = [
   ["운영사 watchdog", stepStatus("Build watchdog runner", "todo"), "`npm run operator:watchdog`"],
   ["운영사 trial dry-run", stepStatus("Create supervised trial dry-run", "todo"), "`npm run operator:trial:dry-run`"],
   ["운영사 2h readiness", stepStatus("Add 2h supervised trial readiness gate", "todo"), "`npm run operator:trial:readiness`"],
+  ["운영 상황판", stepStatus("Add operator control room and playable mode", "todo"), "`docs/OPERATOR_CONTROL_ROOM.md`, `npm run check:control-room`"],
+  ["사람 플레이 모드", fileStatus(["docs/PLAYABLE_MODE.md", "scripts/prepare-playable-main.mjs"]), "`npm run play:main`, port 5174"],
   [
     "Sprite batch QA gate",
     stepStatus("Starter seed sprite-pipeline first batch", "review"),
@@ -66,6 +68,7 @@ const commands = [
   "npm run check:asset-normalization",
   "npm run check:playtest-intake",
   "npm run check:gtm-mock",
+  "npm run check:control-room",
   "npm run check:operator",
   "npm run check:governance",
   "npm run check:audit",
@@ -96,9 +99,9 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 
 ## 다음 작업
 
-1. 다음 게임 기능 작업을 \`items/\` 단위로 등록한다.
-2. Branch protection 사용 가능 조건이 바뀌면 required checks 설정을 별도 승인으로 진행한다.
-3. PR check URL까지 포함하는 audit 확장을 검토한다.
+1. \`docs/OPERATOR_CONTROL_ROOM.md\`에서 active mission/small win/evidence/playable mode를 먼저 확인한다.
+2. 사람이 게임을 확인해야 하면 \`npm run play:main\` 후 \`../strange-seed-shop-play\`에서 port 5174로 실행한다.
+3. 24h dry run은 control room/playable mode PR이 merge되고 main CI가 green이 된 뒤 시작한다.
 
 ## 검증 상태
 
@@ -111,6 +114,7 @@ ${commands.map((command) => `| \`${command}\` | tracked |`).join("\n")}
 - \`main\` Branch protection은 2026-04-28 기준 활성이고 required checks를 강제한다. \`ENABLE_AGENT_AUTOMERGE\` 활성화는 별도 운영 결정으로 유지한다.
 - Browser Use QA는 Phase 0 기준을 통과했지만, 신규 UI가 생기면 같은 캡처 절차로 갱신해야 한다.
 - 대시보드는 자동 생성되지만 검증 결과 자체를 실행해 저장하지는 않는다.
+- 운영 상황판은 살아있는 snapshot이므로 장시간 run 시작/종료/PR 전후에 \`npm run operator:control-room -- --output reports/operations/operator-control-room-YYYYMMDD.md\`로 갱신한다.
 `;
 
 if (process.argv.includes("--check")) {


### PR DESCRIPTION
## 요약

- Issue #87의 Operator Control Room + Playable Mode를 추가합니다.
- 사람이 자동화 중간에 현재 mission, small win, evidence, visual rule, next safe stop을 한눈에 읽을 수 있게 했습니다.
- agent 작업 branch와 별개로 `origin/main` detached worktree를 준비하는 `npm run play:main` / `play:main:install` / `play:main:serve`를 추가했습니다.
- issue/PR 템플릿에 한국어 우선 small win, visual evidence, playable mode 섹션을 추가했습니다.

## Small win

- 퇴근/복귀/중간 확인 시 “지금 agent가 뭘 왜 하고 있고, 나는 게임을 어디서 열면 되는지”를 60초 안에 파악할 수 있습니다.

## 사용자/운영자 가치

- 게임 가치: 사람이 언제든 main 기준 게임을 직접 열어 재미/귀여움/혼란을 확인할 수 있습니다.
- 운영사 가치: 장시간 자동화가 불투명한 무한 루프가 아니라 mission board + evidence + safe stop으로 읽힙니다.

## Before / After 또는 Visual evidence

- Before: 4h trial 결과가 issue/PR/report/dashboard에 흩어져 현재 mission과 playable 상태를 직관적으로 파악하기 어려웠습니다.
- After: `docs/OPERATOR_CONTROL_ROOM.md`, `docs/DASHBOARD.md`, `reports/operations/operator-control-room-20260428.md`가 mission/small win/playable command를 연결합니다.
- N/A 사유: UI/game runtime 변경은 없고 운영 문서/스크립트/템플릿 변경입니다.

## Playable mode

- `npm run play:main:install` PASS — `../strange-seed-shop-play`를 detached `origin/main` worktree로 준비하고 dependencies를 설치했습니다.
- Temporary Vite smoke: `http://127.0.0.1:5174/` HTTP GET PASS, index HTML 614 bytes.
- Smoke server는 종료했으며 장시간 dev server는 남기지 않았습니다.

## 검증

- `npm run check:control-room` PASS
- `npm run check:docs` PASS
- `npm run check:operator` PASS
- `npm run check:all` PASS
- `npm run play:main:install` PASS
- Temporary Vite smoke on `127.0.0.1:5174` PASS

## 안전 범위

- 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음
- `ENABLE_AGENT_AUTOMERGE` 변경 없음
- Branch protection 우회 없음

## 남은 위험

- 이 PR은 in-game UI를 바꾸지 않습니다. 앞으로 UI/game PR마다 실제 before/after screenshot을 PR 본문에 붙이는 운영 규칙을 강제하는 기반입니다.

Closes #87
