### PR TITLE
운영 루프가 완료 보고 후 멈추지 않게 고정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ For browser visual QA, use the Codex Browser Use plugin first:
 - Separate proposal from mutation for risky work.
 - Keep changes scoped, reversible, and tied to acceptance criteria.
 - When adding new implementation work, update the roadmap with status and verification evidence.
+- 장시간 `$ralph`/운영모드에서 완료 보고는 중단 조건이 아니라 체크포인트다. 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 다음 issue를 plan-first로 선택하고 계속 진행한다.
 - Do not stop at a milestone boundary when `docs/ROADMAP.md` names a clear next action and the next action is safe, local, and non-destructive.
 - A progress report is not a handoff. Continue through the current roadmap chain until the next step is blocked, destructive, requires credentials/network approval, or needs a product decision.
 - If a task touches payments, external deployment, credentials, policy-sensitive monetization, destructive migration, or production user data, stop for explicit approval.
@@ -88,7 +89,8 @@ When executing roadmap work:
 2. Verify its acceptance criteria.
 3. Update `docs/ROADMAP.md`.
 4. If the updated `Current Next Action` is clear and safe, continue automatically.
-5. Stop only when the next action is ambiguous, risky, destructive, externally gated, or explicitly paused by the user.
+5. In long-running operator mode, treat summaries as checkpoints and immediately choose the next issue with a `## Plan`.
+6. Stop only when the next action is ambiguous, risky, destructive, externally gated, timeboxed, blocked, or explicitly paused by the user.
 
 ## Documentation Discipline
 

--- a/docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md
+++ b/docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md
@@ -152,6 +152,16 @@ PR이 red check 상태면 verify lane은 실패 job을 읽고, 로컬 재현을 
 
 작업 완료는 구현 종료가 아니라 `draft PR + 검증 증거 + follow-up/audit 링크`가 모두 남은 상태를 뜻한다. 구현 lane은 `docs/PR_AUTOMATION.md`의 작업 완료 gate를 통과해야 하며, 남은 위험이 있으면 GitHub issue 또는 `items/` work record를 만들고 PR 본문·운영 보고서·work item evidence에 교차 링크한다. follow-up이 없을 때도 `none — 이유`를 기록해 에이전트가 누락을 완료로 오인하지 않게 한다.
 
+### completion checkpoint / continuation watchdog
+
+장시간 `$ralph` 운영모드에서 **완료 보고는 중단 조건이 아니라 체크포인트**다. issue 하나가 `implementation -> local verification -> PR -> GitHub checks -> main merge`까지 닫히면 운영자는 최종 답변으로 세션을 닫지 않고 다음 중 하나를 즉시 기록해야 한다.
+
+1. 다음 issue를 plan-first로 선택하고 `items/<id>.md` 또는 동등 plan artifact에 `## Plan`을 쓴다.
+2. 이미 정해진 시간 상한에 도달했다는 final heartbeat/watchdog/daily report를 남긴다.
+3. 명시 중단, 외부 승인, 치명적 blocker, credential/destructive/production boundary 중 하나를 blocker report로 남긴다.
+
+즉, 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 완료 보고 다음 행동은 “요약 후 종료”가 아니라 **다음 issue를 plan-first로 선택**하는 것이다. 이 규칙은 사용자가 기대한 6~8시간 또는 향후 24시간 운영을 위해 completion gate 위에 얹히는 continuation watchdog으로 취급한다.
+
 ### watchdog runner
 
 Milestone 7부터 watchdog runner는 heartbeat ledger를 읽어 `fresh`, `stale`, `missing`, `invalid` 상태를 판정한다. v0 runner는 deterministic `--now` 입력을 지원해 CI에서 장시간 대기 없이 freshness 판정을 검증한다. 실제 재시작은 별도 승인된 supervised trial에서만 수행하고, 기본 동작은 report 생성과 안전한 중단이다.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,6 +1,6 @@
 # 프로젝트 대시보드
 
-Updated: 2026-04-28
+Updated: 2026-04-29
 
 > 이 파일은 `npm run update:dashboard`로 갱신한다. 수동 편집 후에는 `npm run check:dashboard`가 실패할 수 있다.
 
@@ -26,6 +26,7 @@ Updated: 2026-04-28
 | 운영사 trial dry-run | review | `npm run operator:trial:dry-run` |
 | 운영사 2h readiness | review | `npm run operator:trial:readiness` |
 | 운영 상황판 | review | `docs/OPERATOR_CONTROL_ROOM.md`, `npm run check:control-room` |
+| 운영 루프 지속성 | active | Issue #115, `npm run check:operator` |
 | 사람 플레이 모드 | verified | `npm run play:main`, port 5174 |
 | Sprite batch QA gate | review | `npm run check:sprite-batch` |
 | 플레이테스트 intake | review | `npm run check:playtest-intake` |
@@ -36,16 +37,17 @@ Updated: 2026-04-28
 
 | 상태 | 개수 |
 | --- | ---: |
-| done | 38 |
+| done | 39 |
 | review | 61 |
 | todo | 2 |
 | blocked | 0 |
 
 ## 다음 작업
 
-1. `docs/OPERATOR_CONTROL_ROOM.md`에서 active mission/small win/evidence/playable mode를 먼저 확인한다.
-2. 사람이 게임을 확인해야 하면 `npm run play:main` 후 `../strange-seed-shop-play`에서 port 5174로 실행한다.
-3. 24h dry run은 control room/playable mode PR이 merge되고 main CI가 green이 된 뒤 시작한다.
+1. `docs/ROADMAP.md`의 Current Next Action과 `docs/OPERATOR_CONTROL_ROOM.md`의 active mission/small win/evidence/playable mode를 먼저 확인한다.
+2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 issue를 plan-first로 선택한다.
+3. 사람이 게임을 확인해야 하면 `npm run play:main` 후 `../strange-seed-shop-play`에서 port 5174로 실행한다.
+4. 24h dry run은 heartbeat/watchdog/continuation gate가 green이고 main CI가 green인 뒤 시작한다.
 
 ## 검증 상태
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -70,6 +70,8 @@ During a supervised run:
   - merge or blocker state
 - Prefer small, reversible PRs over one large overnight diff.
 - When visual work changes UI, follow Browser Use first policy and save visual evidence under `reports/visual/`.
+- Treat every issue completion as a continuation checkpoint: **완료 보고는 중단 조건이 아니라 체크포인트**다.
+- If the user has asked for an ongoing operator run and no stop rule is active, immediately choose the next issue를 plan-first로 선택하고 `## Plan` artifact를 만든 뒤 다음 loop를 시작한다.
 
 ## Recover procedure
 
@@ -93,6 +95,8 @@ Stop a long-running operator session only when one of these is true:
 - A destructive, credential-gated, external-production, or materially branching decision is required.
 - A hard blocker has a written report and no safe recovery path remains.
 - The user explicitly says stop/cancel/abort.
+
+Do not stop only because a PR was merged, a local report was written, or a “completed work” summary is ready. 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 summary는 다음 issue로 이어지는 checkpoint이고, 다음 issue를 plan-first로 선택해야 한다.
 
 Before stopping, record:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ Goal: P0가 단순히 기능이 돌아가는 상태가 아니라, 첫 화면이 
 | First harvest reveal reward polish | done | Issue #103, PR #108, `items/0062-harvest-reveal-polish.md`, visual evidence, main CI `25063830331` | 첫 수확 reveal이 일반 모달이 아니라 수집형 게임 보상 화면처럼 읽히고 CTA가 393/360에서 잘리지 않음 |
 | Playfield tap/harvest feedback | done | Issue #109, PR #110, `items/0063-playfield-tap-harvest-feedback.md`, `reports/visual/p0-playfield-tap-harvest-feedback-20260429.md`, main CI `25066468406` | 성장 탭과 ready 수확 탭이 `qaFxTelemetry=1` Playwright gate와 mobile screenshot으로 즉시 피드백을 검증함 |
 | Mobile tab card polish | done | Issue #111, PR #112, `items/0064-mobile-tab-card-polish.md`, `reports/visual/p0-mobile-tab-card-polish-20260429.md`, main CI `25067574458` | seeds/album 탭이 수집 게임 메뉴처럼 읽히고 full-screen tab regression이 유지됨 |
-| Expedition/shop card polish | active | Issue #113, `items/0065-expedition-shop-card-polish.md`, `reports/visual/p0-expedition-shop-card-polish-20260429.md` | expedition/shop 탭이 같은 게임 메뉴 카드 언어를 공유하고 mock shop safety를 유지함 |
+| Expedition/shop card polish | done | Issue #113, PR #114, `items/0065-expedition-shop-card-polish.md`, `reports/visual/p0-expedition-shop-card-polish-20260429.md`, main CI `25068421504` | expedition/shop 탭이 같은 게임 메뉴 카드 언어를 공유하고 mock shop safety를 유지함 |
 
 Exit criteria: 위 항목이 모두 검증되고, `npm run check:all` 및 mobile/desktop visual evidence가 최신 main에서 통과할 때 P0 UI/UX Rescue를 닫는다.
 
@@ -208,6 +208,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Harden heartbeat daemon before 24h run | review | Issue #84, `scripts/operator-heartbeat-daemon.mjs`, `reports/operations/heartbeat-daemon-hardening-20260428.md`, `items/0051-heartbeat-daemon-hardening.md` | 독립 heartbeat daemon, stale-gap dry-run guard, watchdog stuck-output guard로 600초 초과 gap을 완료로 오인하지 않게 한다 |
 | Add operator control room and playable mode | review | Issue #87, `docs/OPERATOR_CONTROL_ROOM.md`, `docs/PLAYABLE_MODE.md`, `.github/ISSUE_TEMPLATE/agent-work-item.md`, `.github/pull_request_template.md`, `scripts/prepare-playable-main.mjs`, `items/0052-operator-control-room-playable-mode.md` | 사람이 active mission, small win, visual evidence, PR/issue, playable main command를 한 화면에서 파악하고 agent 작업 중에도 게임을 실행할 수 있음 |
 | Issue-level plan-first gate | done | Issue #106, PR #107, `items/0061-issue-plan-first-operating-rule.md`, operator docs/checker | 모든 issue/work-item 단위 작업은 개발 전에 `## Plan` artifact를 만들고 검증 계획을 기록해야 하며 main CI가 통과함 |
+| Operator continuation watchdog | active | Issue #115, `items/0066-operator-continuation-watchdog.md`, `reports/operations/operator-continuation-watchdog-20260429.md` | 완료 보고는 중단 조건이 아니라 체크포인트이며, 명시 중단/시간 상한/외부 승인/치명적 blocker가 없으면 다음 issue를 plan-first로 선택함 |
 
 ## Milestone 8: Feedback + GTM Mock Intake
 
@@ -233,14 +234,14 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-현재 운영모드는 **북극성 지속 운영 루프**다. P0가 끝나도 멈추지 않고 게임 북극성(첫 5분 귀여움/수집 욕구)과 운영사 북극성(issue intake -> plan -> 구현 -> 검증 -> PR -> CI 복구 -> follow-up evidence)을 향해 계속 진행한다.
+현재 운영모드는 **북극성 지속 운영 루프**다. P0가 끝나도 멈추지 않고 게임 북극성(첫 5분 귀여움/수집 욕구)과 운영사 북극성(issue intake -> plan -> 구현 -> 검증 -> PR -> CI 복구 -> follow-up evidence)을 향해 계속 진행한다. 완료 보고는 중단 조건이 아니라 체크포인트이며, 명시 중단/시간 상한/외부 승인/치명적 blocker가 없으면 다음 issue를 plan-first로 선택한다.
 
 즉시 다음 작업:
 
-1. Issue #113 원정/상점 탭 게임 메뉴 카드 UI polish를 `items/0065-expedition-shop-card-polish.md` plan 기준으로 구현·검증·PR화한다.
-2. 각 issue는 작은 승리, 수용 기준, 검증 명령, visual evidence를 남기고 PR/CI/main merge까지 반복한다.
-3. P0 UI/UX Rescue가 닫힌 뒤에도 다음 north-star issue를 만들고 같은 루프를 지속한다.
-4. 다음 후보는 reward FX, tap/harvest feedback, 탭별 game UI skinning, 운영 상황판 가독성 개선이다.
+1. Issue #115 Operator continuation watchdog을 `items/0066-operator-continuation-watchdog.md` plan 기준으로 구현·검증·PR화한다.
+2. PR/CI/main merge 후 완료 리포트로 멈추지 않고 다음 issue를 plan-first로 선택한다.
+3. 각 issue는 작은 승리, 수용 기준, 검증 명령, visual evidence 또는 `N/A — UI 변화 없음` 사유를 남기고 PR/CI/main merge까지 반복한다.
+4. 다음 게임 후보는 reward FX, harvest reveal micro-motion, tap/harvest feedback 심화, 탭별 game UI skinning, 운영 상황판 가독성 개선이다.
 
 ## Previous Next Action History
 

--- a/items/0066-operator-continuation-watchdog.md
+++ b/items/0066-operator-continuation-watchdog.md
@@ -1,0 +1,53 @@
+# Operator continuation watchdog
+
+Status: active
+Work type: agent_ops
+Issue: #115
+Owner: agent
+Created: 2026-04-29
+Updated: 2026-04-29
+Scope-risk: narrow
+
+## Intent
+
+이번 `$ralph` 루프는 PR/CI/main merge를 성공적으로 반복했지만, 완료 리포트를 내면서 장시간 운영을 계속하지 않고 약 1시간 수준에서 멈췄다. 운영사 북극성은 “완료 보고”가 아니라 “다음 issue를 스스로 선택하고 plan-first로 이어가는 반복”이므로, 완료 보고 후 조기 종료를 운영 버그로 고정한다.
+
+## Small win
+
+완료 보고는 중단 조건이 아니라 checkpoint이며, 명시 중단·시간 상한·외부 승인·치명적 blocker가 없으면 다음 issue를 plan-first로 선택해야 한다는 규칙을 문서와 checker가 검증한다.
+
+## Plan
+
+1. 운영 모델에 completion checkpoint / continuation watchdog 규칙을 추가한다.
+2. runbook의 stop/summarize 절차에 “보고 후 다음 issue 자동 진입”과 “stop 조건 외 종료 금지”를 명시한다.
+3. `reports/operations/operator-continuation-watchdog-20260429.md`에 원인, 재발 방지, 검증 증거를 남긴다.
+4. `scripts/check-operator.mjs`가 이 item/report/docs 문구를 필수 검증하도록 갱신한다.
+5. roadmap/dashboard를 Issue #115 기준으로 갱신하고, 로컬 검증 후 PR/CI/main merge까지 진행한다.
+
+## Acceptance Criteria
+
+- `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`에 “완료 보고는 중단 조건이 아니라 체크포인트”와 “다음 issue를 plan-first로 선택” 규칙이 들어간다.
+- `docs/OPERATOR_RUNBOOK.md`가 stop 조건 외에는 장시간 운영을 종료하지 않고 다음 루프를 시작하도록 명시한다.
+- `reports/operations/operator-continuation-watchdog-20260429.md`가 이번 1시간 조기 종료의 원인과 방지 규칙을 기록한다.
+- `npm run check:operator`와 `npm run check:all`이 통과한다.
+
+## Evidence
+
+- Issue: #115
+- Report: `reports/operations/operator-continuation-watchdog-20260429.md`
+- Verification:
+  - `npm run check:operator` — pass
+  - `npm run check:dashboard` — pass
+  - `npm run check:all` — pass
+
+## Apply Conditions
+
+- 실제 6h/24h 실행을 이 issue 안에서 새로 시작하지 않는다.
+- 제품 UI/게임 로직은 이번 issue에서 변경하지 않는다.
+- 결제, 로그인, 광고, 외부 배포, 고객 데이터, 실채널 GTM은 건드리지 않는다.
+
+## Verification
+
+- `npm run check:operator`
+- `npm run check:dashboard`
+- `npm run check:all`

--- a/reports/operations/operator-continuation-watchdog-20260429.md
+++ b/reports/operations/operator-continuation-watchdog-20260429.md
@@ -1,0 +1,38 @@
+# Operator Continuation Watchdog
+
+Status: active
+Issue: #115
+Item: `items/0066-operator-continuation-watchdog.md`
+Created: 2026-04-29
+
+## 원인
+
+이번 운영 루프는 Issue #109/#111/#113을 각각 PR #110/#112/#114로 merge하고 main CI를 확인했지만, 그 뒤 “완료 리포트”를 내면서 사실상 세션을 닫았다. 사용자가 원한 것은 6~8시간 이상 이어지는 운영사 루프였으므로, 이것은 제품 버그가 아니라 운영 루프의 조기 종료 버그다.
+
+## 재발 방지 규칙
+
+- 완료 보고는 중단 조건이 아니라 체크포인트다.
+- 장시간 `$ralph`/운영모드에서는 PR merge와 main CI 확인 후에도 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 멈추지 않는다.
+- 다음 행동은 “최종 요약 후 종료”가 아니라 다음 issue를 plan-first로 선택하는 것이다.
+- 다음 issue는 구현 전에 `items/<id>.md` 또는 동등 문서에 `## Plan`, 수용 기준, 검증 명령, 금지 범위를 남겨야 한다.
+
+## 현재 issue의 small win
+
+Issue #115는 실제 6h/24h 실행을 새로 시작하지 않고, 위 continuation watchdog 규칙을 `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, `docs/OPERATOR_RUNBOOK.md`, `AGENTS.md`, `scripts/check-operator.mjs`에 고정한다.
+
+## 검증 계획
+
+- `npm run check:operator`
+- `npm run check:dashboard`
+- `npm run check:all`
+
+## 검증 결과
+
+- `npm run check:operator` — pass, requiredPaths 53, failures 0.
+- `npm run check:dashboard` — pass, `docs/DASHBOARD.md` 최신.
+- `npm run check:all` — pass, Playwright visual 12개 통과 및 production build 성공.
+
+## 남은 리스크
+
+- 이 규칙은 문서/체커 수준의 방지 장치다. 실제 6h/24h 무중단 운영 품질은 heartbeat daemon, watchdog, PR/CI polling, daily report가 함께 돌아가는 별도 trial에서 계속 검증해야 한다.
+- 컨텍스트 한계나 플랫폼 세션 종료는 코드로 완전히 막을 수 없으므로, 종료 전 checkpoint와 next issue 기록을 더 자주 남겨야 한다.

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -45,6 +45,7 @@ const requiredPaths = [
   "items/0051-heartbeat-daemon-hardening.md",
   "items/0052-operator-control-room-playable-mode.md",
   "items/0061-issue-plan-first-operating-rule.md",
+  "items/0066-operator-continuation-watchdog.md",
   "items/0029-operator-completion-gate.md",
   "docs/OPERATOR_RUNBOOK.md",
   "docs/OPERATOR_CONTROL_ROOM.md",
@@ -56,6 +57,7 @@ const requiredPaths = [
   "reports/operations/operator-live-status-20260428.md",
   "reports/operations/heartbeat-daemon-hardening-20260428.md",
   "reports/operations/operator-control-room-20260428.md",
+  "reports/operations/operator-continuation-watchdog-20260429.md",
   "reports/research/agent_operator_control_room_research_20260428.md",
   "reports/operations/fixtures/operator-trial-dry-run-scenario-20260428.json",
   "reports/operations/fixtures/operator-trial-stale-gap-scenario-20260428.json",
@@ -225,24 +227,59 @@ requirePhrases("items/0061-issue-plan-first-operating-rule.md", [
   "npm run check:all"
 ]);
 
+requirePhrases("items/0066-operator-continuation-watchdog.md", [
+  "Status: active",
+  "Work type: agent_ops",
+  "Issue: #115",
+  "## Plan",
+  "완료 보고는 중단 조건이 아니라 checkpoint",
+  "다음 issue를 plan-first로 선택",
+  "명시 중단",
+  "시간 상한",
+  "외부 승인",
+  "치명적 blocker",
+  "npm run check:operator",
+  "npm run check:all"
+]);
+
 requirePhrases("AGENTS.md", [
   "Issue/work-item 단위 작업은 반드시 plan-first로 시작한다",
   "## Plan",
   "수용 기준",
-  "검증 명령"
+  "검증 명령",
+  "완료 보고는 중단 조건이 아니라 체크포인트",
+  "다음 issue를 plan-first로 선택"
 ]);
 
 requirePhrases("docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md", [
   "issue -> plan artifact -> branch",
   "plan-first gate",
   "Plan은 거창한 PRD가 아니라도 된다",
-  "plan artifact exists and includes `## Plan`"
+  "plan artifact exists and includes `## Plan`",
+  "completion checkpoint / continuation watchdog",
+  "완료 보고는 중단 조건이 아니라 체크포인트",
+  "다음 issue를 plan-first로 선택",
+  "명시 중단, 시간 상한, 외부 승인, 치명적 blocker"
 ]);
 
 requirePhrases("docs/OPERATOR_RUNBOOK.md", [
   "Create or update the issue plan artifact before implementation",
   "Plan artifact가 없으면 branch 구현",
-  "plan artifact with `## Plan`"
+  "plan artifact with `## Plan`",
+  "완료 보고는 중단 조건이 아니라 체크포인트",
+  "다음 issue를 plan-first로 선택",
+  "명시 중단, 시간 상한, 외부 승인, 치명적 blocker"
+]);
+
+requirePhrases("reports/operations/operator-continuation-watchdog-20260429.md", [
+  "Status: active",
+  "Issue: #115",
+  "items/0066-operator-continuation-watchdog.md",
+  "완료 보고는 중단 조건이 아니라 체크포인트",
+  "명시 중단, 시간 상한, 외부 승인, 치명적 blocker",
+  "다음 issue를 plan-first로 선택",
+  "npm run check:operator",
+  "npm run check:all"
 ]);
 
 requirePhrases("docs/PLAYABLE_MODE.md", [

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -45,6 +45,7 @@ const rows = [
   ["운영사 trial dry-run", stepStatus("Create supervised trial dry-run", "todo"), "`npm run operator:trial:dry-run`"],
   ["운영사 2h readiness", stepStatus("Add 2h supervised trial readiness gate", "todo"), "`npm run operator:trial:readiness`"],
   ["운영 상황판", stepStatus("Add operator control room and playable mode", "todo"), "`docs/OPERATOR_CONTROL_ROOM.md`, `npm run check:control-room`"],
+  ["운영 루프 지속성", stepStatus("Operator continuation watchdog", "todo"), "Issue #115, `npm run check:operator`"],
   ["사람 플레이 모드", fileStatus(["docs/PLAYABLE_MODE.md", "scripts/prepare-playable-main.mjs"]), "`npm run play:main`, port 5174"],
   [
     "Sprite batch QA gate",
@@ -99,9 +100,10 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 
 ## 다음 작업
 
-1. \`docs/OPERATOR_CONTROL_ROOM.md\`에서 active mission/small win/evidence/playable mode를 먼저 확인한다.
-2. 사람이 게임을 확인해야 하면 \`npm run play:main\` 후 \`../strange-seed-shop-play\`에서 port 5174로 실행한다.
-3. 24h dry run은 control room/playable mode PR이 merge되고 main CI가 green이 된 뒤 시작한다.
+1. \`docs/ROADMAP.md\`의 Current Next Action과 \`docs/OPERATOR_CONTROL_ROOM.md\`의 active mission/small win/evidence/playable mode를 먼저 확인한다.
+2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 issue를 plan-first로 선택한다.
+3. 사람이 게임을 확인해야 하면 \`npm run play:main\` 후 \`../strange-seed-shop-play\`에서 port 5174로 실행한다.
+4. 24h dry run은 heartbeat/watchdog/continuation gate가 green이고 main CI가 green인 뒤 시작한다.
 
 ## 검증 상태
 


### PR DESCRIPTION
## Small win

Ralph/운영모드가 PR merge 후 완료 리포트에서 멈추지 않도록, 완료 보고를 checkpoint로 정의하고 stop rule이 없으면 다음 issue를 plan-first로 선택하도록 문서/체커/대시보드에 고정했습니다.

## Plan-first evidence

- Plan artifact: `items/0066-operator-continuation-watchdog.md`
- Issue: #115
- Operation report: `reports/operations/operator-continuation-watchdog-20260429.md`

## 변경 요약

- `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, `docs/OPERATOR_RUNBOOK.md`, `AGENTS.md`에 continuation watchdog 규칙 추가
- `scripts/check-operator.mjs`가 Issue #115 item/report/docs 핵심 문구를 검증하도록 확장
- `docs/ROADMAP.md`, `docs/DASHBOARD.md`, `scripts/update-dashboard.mjs`에 현재 active operator gate 반영

## Verification

- `npm run check:operator` — pass
- `npm run check:dashboard` — pass
- `npm run check:all` — pass

## Before / After 또는 Visual evidence

- N/A — 운영 문서/checker/dashboard 변경이며 UI 변화 없음

## Playable mode

- N/A — 제품 코드 변경 없음. 사람 플레이 모드는 기존 `npm run play:main` 유지.

## Risks

- 실제 6h/24h 무중단 run은 이번 issue 범위 밖입니다. 이 PR은 조기 종료 재발 방지 규칙과 checker를 고정합니다.

Closes #115
