### PR TITLE
P0.5 idle core 방향을 source of truth로 고정

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ For browser visual QA, use the Codex Browser Use plugin first:
 - Keep changes scoped, reversible, and tied to acceptance criteria.
 - When adding new implementation work, update the roadmap with status and verification evidence.
 - 장시간 `$ralph`/운영모드에서 완료 보고는 중단 조건이 아니라 체크포인트다. 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 다음 issue를 plan-first로 선택하고 계속 진행한다.
+- Issue 종료 전 `items/<id>.md`, `docs/ROADMAP.md`, `docs/DASHBOARD.md`(`npm run update:dashboard`), GitHub issue/PR evidence를 갱신한다. 세부 규칙은 `docs/PROJECT_COMMANDS.md`와 `docs/OPERATOR_RUNBOOK.md`를 따른다.
 - Do not stop at a milestone boundary when `docs/ROADMAP.md` names a clear next action and the next action is safe, local, and non-destructive.
 - A progress report is not a handoff. Continue through the current roadmap chain until the next step is blocked, destructive, requires credentials/network approval, or needs a product decision.
 - If a task touches payments, external deployment, credentials, policy-sensitive monetization, destructive migration, or production user data, stop for explicit approval.

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -40,7 +40,7 @@ Updated: 2026-04-29
 | --- | ---: |
 | done | 40 |
 | review | 61 |
-| todo | 2 |
+| todo | 6 |
 | blocked | 0 |
 
 ## 다음 작업

--- a/docs/IDLE_CORE_CREATIVE_GUIDE.md
+++ b/docs/IDLE_CORE_CREATIVE_GUIDE.md
@@ -1,0 +1,155 @@
+# Idle Core Creative Guide
+
+Status: draft-v0
+Owner: agent
+Updated: 2026-04-29
+Scope: P0.5 idle core + production game feel rescue
+
+## 목적
+
+`이상한 씨앗상회`는 현재 귀여운 수집 UI 프로토타입에 가깝고, 아직 production급 idle game으로 플레이할 콘텐츠와 재미가 부족하다. 이 문서는 게임 기획, UI/UX, 에셋, 연출, Codex 작업 방식을 분리하지 않고 하나의 vertical slice 기준으로 묶는다.
+
+핵심 전환:
+
+> 귀여운 씨앗 수집 UI에서, 식물 생명체들이 정원을 자동화하고 주문을 처리하고 탐험을 다녀오며 온실 제국을 키우는 idle collection tycoon으로 전환한다.
+
+## 레퍼런스에서 배운 원칙
+
+- Egg, Inc.: 귀여운 외피 아래 농장 확장, 연구, prestige, contracts, spaceships/artifacts 같은 장기 메타가 있다.
+- Idle Miner Tycoon: 광산/매니저/자동화/오프라인 수익/이벤트/대륙 확장으로 생산 엔진을 계속 키운다.
+- Cell to Singularity: 클릭/idle 위에 거대한 tech tree와 발견의 서사를 얹어 다음 콘텐츠를 계속 보여준다.
+
+공통점:
+
+1. 생산 엔진이 화면에 보인다.
+2. 업그레이드 선택이 있다.
+3. 다음 해금 목표가 계속 보인다.
+4. 오프라인 진행이 의미 있다.
+5. 장기 메타가 있다.
+6. UI와 에셋은 기능 장식이 아니라 core loop의 일부다.
+
+## Game Fantasy
+
+플레이어는 이상한 씨앗에서 태어난 식물 생명체들을 모아 정원을 자동화한다. 생명체들은 각자 역할을 가지고 잎, 꽃가루, 재료를 생산하거나 주문을 돕고, 탐험을 다녀오며 더 희귀한 씨앗과 연구를 열어준다.
+
+## Core Loop Contract
+
+```text
+씨앗 심기
+→ 생명체 탄생
+→ 생명체가 정원에서 일함
+→ 자동 생산
+→ 주문/의뢰 납품
+→ 새 씨앗/시설/탐험 해금
+→ 더 희귀한 생명체 수집
+→ 연구/계절 메타
+→ 반복
+```
+
+모든 게임 기능 issue는 아래를 함께 정의해야 한다.
+
+- Player fun target: 이 작업이 어떤 재미를 만드는가?
+- Core loop role: 생산, 수집, 주문, 탐험, 연구, 복귀 중 어디에 속하는가?
+- Screen moment: 플레이어가 언제 어디서 이것을 보는가?
+- Required assets: 캐릭터, 아이콘, FX, 배경, 성장 단계.
+- Game-feel requirements: 탭, 수확, 납품, 보상 순간의 반응.
+- Acceptance criteria: 기능, 화면, 에셋, visual QA가 함께 통과해야 한다.
+
+## Production UI Bar
+
+- 첫 화면은 생산 엔진이 보여야 한다. 정적인 메뉴/패널이 아니라 생명체와 자원 흐름이 보여야 한다.
+- 생명체는 도감 보상 카드가 아니라 정원 경제에 참여하는 actor여야 한다.
+- CTA는 `확인/완료`보다 `수확`, `납품`, `보내기`, `연구`, `배치` 같은 게임 동사를 사용한다.
+- 숫자 변화는 화면에서 느껴져야 한다: floating reward, 자원 통 채움, 주문 상자 진행률, 생산 tick.
+- 모바일은 하나의 game frame이다. 정원과 메뉴가 동시에 보이는 대시보드가 아니라, 하단 탭으로 전환되는 게임 화면이어야 한다.
+- 패널은 플레이필드를 가리지 않고, 탭 화면은 게임의 다른 공간처럼 보여야 한다.
+
+## Asset Bible v0
+
+### Creature asset minimum
+
+각 주요 생명체는 vertical slice에서 최소 아래 상태를 목표로 한다.
+
+- `portrait`: reveal/modal/card용 고해상도 초상
+- `idle`: 정원 배치 상태
+- `work`: 생산/주문/탐험 준비 상태
+- `celebrate`: 수확/납품/해금 보상 순간
+- `silhouette`: 미발견 도감 슬롯
+- `small_icon`: 32~64px UI 칩
+
+### Seed/crop asset minimum
+
+- `seed`
+- `sprout`
+- `growing`
+- `ready`
+- `harvest_pop`
+
+### System assets
+
+- leaf icon
+- pollen icon
+- material icon
+- order crate
+- research icon
+- expedition map marker
+- reward burst FX
+- production tick FX
+
+### Quality bar
+
+- creature/item/icon/fx는 투명 배경이 기본이다.
+- 64px에서도 형태와 역할이 읽혀야 한다.
+- 동일 시점, 동일 조명, 동일 외곽선 언어를 유지한다.
+- checkerboard/흰 배경이 노출되면 실패다.
+- manifest 등록 전 asset review를 통과해야 한다.
+
+## Codex 작업 방식
+
+Codex는 게임 기획과 에셋을 분리해서 처리하지 않는다. 작은 vertical slice마다 아래 순서를 따른다.
+
+1. Reference teardown: 이 slice가 어떤 idle game 재미를 차용하는지 명시.
+2. Creative brief: 플레이어 감정, core loop role, 화면 순간 정의.
+3. Asset plan: 필요한 gameplay asset과 크기/용도/투명 배경 여부 정의.
+4. Prompt batch: asset prompt 작성.
+5. Image generation: 필요한 asset만 생성.
+6. Asset review: 투명도, 작은 크기 판독성, 스타일 일관성 확인.
+7. Manifest integration: runtime에서 정적 asset만 사용.
+8. Visual QA: Playwright/Browser Use/Computer Use fallback으로 실제 화면 증거 저장.
+
+## P0.5 추천 vertical slice
+
+### 목표
+
+첫 5분 안에 플레이어가 “귀엽다”를 넘어서 “이 정원이 자동으로 커지고, 다음 주문/생명체/연구가 기다린다”를 느끼게 한다.
+
+### Slice 1: Creature role + auto production v0
+
+- 첫 생명체가 정원에 배치되어 잎을 천천히 생산한다.
+- 생산 tick이 화면에 보인다.
+- 첫 업그레이드는 단순 plot unlock이 아니라 생산 엔진 강화처럼 읽힌다.
+
+### Slice 2: Order/commission v0
+
+- 짧은 주문이 생긴다: 예) `말랑잎 포리의 잎 20개 납품`.
+- 납품 progress와 보상이 보인다.
+- 보상은 새 씨앗/연구/탐험으로 이어진다.
+
+### Slice 3: Production garden UI v0
+
+- 정원 화면에서 생명체, 생산 자원, 주문 상자가 동시에 읽힌다.
+- 기존 앱 패널 느낌을 줄이고 게임 HUD와 playfield 중심으로 재배치한다.
+
+### Slice 4: Asset batch v0
+
+- 첫 creature role state assets
+- 생산 tick/reward FX
+- order crate/resource icons
+
+## 금지/주의
+
+- 새 시스템을 추가하더라도 첫 5분을 더 복잡하게 만들면 실패다.
+- 숫자만 늘리는 idle은 부족하다. 화면에서 생산과 보상 순간이 느껴져야 한다.
+- UI polish만 하고 core loop가 재미없으면 실패다.
+- 에셋만 늘리고 gameplay role이 없으면 실패다.
+- 운영사 인프라 작업은 게임 제작을 막는 blocker일 때만 우선한다.

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -108,6 +108,25 @@ Before stopping, record:
 6. Main branch CI status if anything merged.
 7. Daily operating report.
 
+## Work completion documentation checklist
+
+Every issue-level loop, including planning-only work, must update durable source of truth before PR publication or completion.
+
+Always update:
+
+1. `items/<id>.md` — status, small win, plan progress, verification, PR/CI evidence.
+2. `docs/ROADMAP.md` — milestone row status and `Current Next Action`.
+3. `docs/DASHBOARD.md` — generated with `npm run update:dashboard`, then checked with `npm run check:dashboard`.
+4. GitHub issue/PR — acceptance criteria, verification, evidence, risk, and visual evidence or `N/A`.
+
+Update conditionally:
+
+- `docs/README.md` and `scripts/check-docs-index.mjs` when a new source-of-truth document is added.
+- `docs/PROJECT_COMMANDS.md`, this runbook, `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, and minimal `AGENTS.md` when operating rules change.
+- `docs/NORTH_STAR.md`, `docs/PRD_PHASE0.md`, `docs/IDLE_CORE_CREATIVE_GUIDE.md`, and `docs/DESIGN_SYSTEM.md` when game direction, design, or asset standards change.
+- `reports/visual/` and `npm run check:visual` when UI/visual behavior changes.
+- `reports/operations/` when an operator run, stuck recovery, or completion checkpoint occurs.
+
 ## Summarize procedure
 
 Every multi-hour or overnight run must produce a daily operating report under `reports/operations/daily-*.md` with these sections:

--- a/docs/PROJECT_COMMANDS.md
+++ b/docs/PROJECT_COMMANDS.md
@@ -34,6 +34,23 @@ Scope: `이상한 씨앗상회` + 에이전트 네이티브 게임 스튜디오/
 7. merge 후 main CI를 확인한다.
 8. 완료 보고는 중단 조건이 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 issue를 plan-first로 선택한다.
 
+### 작업 종료 문서 갱신 규칙
+
+issue 단위 작업이 끝나기 전에는 사람이 요청하지 않아도 아래를 갱신한다.
+
+1. `items/<id>.md`: 상태, small win, plan 이행 여부, 검증 결과, PR/CI evidence.
+2. `docs/ROADMAP.md`: 해당 milestone/step 상태와 `Current Next Action`.
+3. `docs/DASHBOARD.md`: 직접 편집하지 않고 `npm run update:dashboard`로 갱신한 뒤 `npm run check:dashboard`.
+4. GitHub issue/PR: small win, acceptance criteria, verification, evidence, 남은 risk.
+
+조건부 갱신:
+
+- 새 source-of-truth 문서가 생기면 `docs/README.md`와 필요 시 `scripts/check-docs-index.mjs`.
+- 운영 방식/명령/자동화 규칙이 바뀌면 `docs/PROJECT_COMMANDS.md`, `docs/OPERATOR_RUNBOOK.md`, `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, 필요 최소한의 `AGENTS.md`.
+- 게임 방향/재미/디자인/에셋 기준이 바뀌면 `docs/NORTH_STAR.md`, `docs/PRD_PHASE0.md`, `docs/IDLE_CORE_CREATIVE_GUIDE.md`, `docs/DESIGN_SYSTEM.md`.
+- UI/visual 작업이면 `reports/visual/` evidence와 `npm run check:visual`.
+- 운영 실행 결과이면 `reports/operations/`에 해당 실행 보고서.
+
 Stop rules:
 
 - 사용자가 stop/cancel/abort를 명시한다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,9 @@ This folder is the durable memory for `이상한 씨앗상회` and the agent-nat
 | `UX_REVIEW_20260427.md` | Devil's advocate UX review and Milestone 3.5 guardrails | Before design-system implementation |
 | `GAME_STUDIO_REVIEW_20260427.md` | Game Studio 기준 playfield/runtime/sprite 구조 재검토 | Before changing the game runtime or sprite pipeline |
 | `GAME_UI_UX_RESEARCH_20260428.md` | P0 게임 UI/UX 리서치, 화면 비율, HUD, CLI visual QA, alpha asset 결정 | Before major UI/visual QA work |
+| `IDLE_CORE_CREATIVE_GUIDE.md` | P0.5 idle core, production UI, asset bible, Codex vertical-slice workflow | Before game/content/UI/asset feature work |
 | `SESSION_HANDOFF_20260427.md` | 이번 세션의 작업 맥락과 다음 deep interview 시작점 | Before starting a new session |
+| `SESSION_HANDOFF_20260429.md` | 최신 운영/게임 방향 전환과 재개 지점 | Before restarting Codex/OMX after this session |
 | `AUTONOMOUS_PROJECT_OPERATING_MODEL.md` | ClawSweeper-inspired agent operating model | Before automation/project-management work |
 | `OPERATOR_RUNBOOK.md` | 장시간 `$ralph` 운영사의 start, monitor, recover, stop, summarize 절차 | Before supervised 4h/24h operator runs |
 | `OPERATOR_CONTROL_ROOM.md` | 사람이 현재 mission, small win, evidence, playable mode를 한눈에 보는 운영 상황판 | Before/while running autonomous sessions |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,18 @@ Status values:
 
 공통 헌장은 `docs/NORTH_STAR.md`가 소유한다. 게임 작업은 재미와 수집 욕구를, 운영사 작업은 장시간 자율성과 증거 기반 복구 능력을 개선해야 한다.
 
+## P0.5 Idle Core + Creative Rescue
+
+Goal: 현재 수집 UI 프로토타입을 production급 idle collection tycoon vertical slice로 전환한다. 게임 기획, UI, 에셋, 연출을 분리하지 않고 core loop 재미를 먼저 만든다.
+
+| Step | Status | Output | Acceptance Criteria |
+| --- | --- | --- | --- |
+| Idle core creative guide | active | `docs/IDLE_CORE_CREATIVE_GUIDE.md`, `docs/SESSION_HANDOFF_20260429.md` | Egg, Inc./Idle Miner/Cell to Singularity에서 배운 생산 엔진, 장기 메타, asset bible, Codex vertical-slice workflow가 문서화됨 |
+| Creature role + auto production v0 | todo | game vertical slice item, production tick UI, visual evidence | 첫 생명체가 정원 경제에 참여하고 생산 tick이 화면에서 읽힘 |
+| Order/commission v0 | todo | order data/UI, reward loop, visual evidence | 짧은 주문 목표가 생기고 납품 보상이 다음 씨앗/연구/탐험 목표로 이어짐 |
+| Production garden UI v0 | todo | Phaser/React garden UI update, screenshots | 정원 화면이 패널 앱이 아니라 생산 엔진이 보이는 모바일 게임 화면처럼 읽힘 |
+| Core asset batch v0 | todo | creature work/celebrate, order crate, reward FX, manifest | gameplay role이 있는 asset batch가 투명 배경/작은 크기 판독성/manifest 검증을 통과함 |
+
 ## P0 Game Studio Operating Mode — UI/UX Rescue
 
 Goal: P0가 단순히 기능이 돌아가는 상태가 아니라, 첫 화면이 게임처럼 보이고 자동화가 실제 화면 회귀를 잡는 상태가 될 때까지 운영모드로 반복한다.
@@ -239,10 +251,10 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 즉시 다음 작업:
 
-1. Issue #117 Project command surface를 `items/0067-project-command-surface.md` plan 기준으로 구현·검증·PR화한다.
-2. `$seed-ops`, `$seed-brief`, `$seed-design`, `$seed-qa`, `$seed-play`를 project-local skill과 문서로 고정한다.
-3. PR/CI/main merge 후 완료 리포트로 멈추지 않고 다음 issue를 plan-first로 선택한다.
-4. 다음 게임 후보는 reward FX, harvest reveal micro-motion, tap/harvest feedback 심화, 탭별 game UI skinning, 운영 상황판 가독성 개선이다.
+1. `$seed-ops`로 `게임: P0.5 idle core creative rescue vertical slice 설계` issue를 만들고 plan-first item을 작성한다.
+2. `docs/IDLE_CORE_CREATIVE_GUIDE.md` 기준으로 첫 vertical slice를 `creature role + auto production + order v0`로 좁힌다.
+3. 다음 구현 PR은 게임 core, UI, 에셋, visual QA를 분리하지 않는 작은 vertical slice로 만든다.
+4. 운영사 인프라는 CI/QA/상태 이해가 게임 개발을 막을 때만 우선한다.
 
 ## Previous Next Action History
 

--- a/docs/SESSION_HANDOFF_20260429.md
+++ b/docs/SESSION_HANDOFF_20260429.md
@@ -1,0 +1,72 @@
+# Session Handoff — 2026-04-29
+
+Status: current-handoff
+Owner: agent
+Updated: 2026-04-29
+
+## 바로 재개하는 방법
+
+새 Codex/OMX 세션은 아래 순서로 읽는다.
+
+1. `AGENTS.md`
+2. `docs/README.md`
+3. `docs/PROJECT_COMMANDS.md`
+4. `docs/NORTH_STAR.md`
+5. `docs/ROADMAP.md`
+6. `docs/IDLE_CORE_CREATIVE_GUIDE.md`
+7. 필요 시 `docs/OPERATOR_RUNBOOK.md`, `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`
+
+## 현재 결론
+
+운영사 인프라는 최소한의 실험을 계속할 수 있을 만큼 있다. 당분간 본질은 운영사 추상화가 아니라 production급 idle collection game을 만드는 것이다.
+
+핵심 방향:
+
+- Codex/Claude/opencode/pi 전체 provider-portable kernel은 지금은 보류한다.
+- `operator:resume` 같은 별도 커널도 지금은 과설계로 본다.
+- OMX는 optional accelerator로 취급하고, source of truth는 `docs/`, `items/`, `reports/`, GitHub issue/PR에 둔다.
+- 다음 큰 축은 P0.5 idle core + creative rescue다.
+
+## 이미 main에 merge된 운영사 기반
+
+- PR #116: completion watchdog. 완료 보고는 중단 조건이 아니라 checkpoint.
+- PR #118: 프로젝트 전용 명령어.
+  - `$seed-ops`: 운영모드
+  - `$seed-brief`: 보고/상황판
+  - `$seed-design`: 설계 대화
+  - `$seed-qa`: 실기 QA
+  - `$seed-play`: 사람 플레이 준비
+
+## 아직 canonical로 승격하지 않은 것
+
+`.omx/plans/provider-portable-operator-kernel-*`에는 provider portability 기획이 있지만, 현재 판단상 v0 실행 대상이 아니다. 필요하면 나중에 `OMX optional boundary` 또는 `Codex/Claude dual harness` issue로 축소해서 다룬다.
+
+## 다음 추천 작업
+
+`$seed-ops`로 다음 issue를 만든다.
+
+추천 issue title:
+
+> 게임: P0.5 idle core creative rescue vertical slice 설계
+
+추천 small win:
+
+> `docs/IDLE_CORE_CREATIVE_GUIDE.md` 기준으로 첫 vertical slice를 `creature role + auto production + order v0`로 정의하고, 구현 가능한 item/PRD/test spec을 만든다.
+
+그 다음 구현 후보:
+
+1. 첫 생명체 역할/자동 생산 v0
+2. 주문/의뢰 v0
+3. 생산 엔진이 보이는 정원 UI v0
+4. creature work/celebrate + reward FX asset batch
+5. 5분 playtest checklist와 visual evidence
+
+## 운영사 판단 규칙
+
+운영사 인프라 작업은 아래 조건일 때만 게임 작업보다 우선한다.
+
+- PR/CI/QA가 막혀 게임 PR을 낼 수 없다.
+- 현재 상태를 사람이 이해하지 못해 다음 게임 작업 선택이 불가능하다.
+- 세션 끊김으로 source of truth가 사라질 위험이 있다.
+
+그 외에는 게임 core, UI, 에셋, playtest를 우선한다.

--- a/items/0068-idle-core-creative-rescue-source-of-truth.md
+++ b/items/0068-idle-core-creative-rescue-source-of-truth.md
@@ -1,0 +1,55 @@
+# Idle core creative rescue source of truth
+
+Status: active
+Work type: game_feature
+Issue: #119
+Owner: agent
+Created: 2026-04-29
+Updated: 2026-04-29
+Scope-risk: narrow
+
+## Intent
+
+세션 중 `이상한 씨앗상회`가 아직 production급 idle game으로 플레이 가능한 수준이 아니며, 운영사 인프라보다 게임 core, 디자인, 에셋, 재미를 함께 끌어올려야 한다는 방향 전환이 있었다. 기획도 source of truth 변경이므로 GitHub issue/PR/main merge 루프로 고정한다.
+
+## Small win
+
+`docs/IDLE_CORE_CREATIVE_GUIDE.md`와 `docs/SESSION_HANDOFF_20260429.md`를 추가하고, `docs/README.md`와 `docs/ROADMAP.md`가 다음 안전 작업을 P0.5 idle core creative rescue로 가리키게 한다.
+
+## Plan
+
+1. 세션 중 작성한 idle core creative guide와 handoff 문서를 source of truth 문서로 정리한다.
+2. `docs/README.md`에 새 문서를 색인한다.
+3. `docs/ROADMAP.md`에 P0.5 Idle Core + Creative Rescue 마일스톤과 Current Next Action을 추가한다.
+4. 작업 종료 문서 갱신 규칙을 `docs/PROJECT_COMMANDS.md`, `docs/OPERATOR_RUNBOOK.md`, `AGENTS.md`에 고정한다.
+5. `npm run check:docs`, `npm run check:dashboard`로 문서 index와 dashboard 갱신을 검증한다.
+6. PR을 만들고 GitHub checks/main CI까지 확인한다.
+
+## Acceptance Criteria
+
+- `docs/IDLE_CORE_CREATIVE_GUIDE.md`가 core loop, production UI, asset bible, Codex vertical-slice workflow를 포함한다.
+- `docs/SESSION_HANDOFF_20260429.md`가 새 세션이 읽을 재개 순서와 다음 `$seed-ops` 작업을 명시한다.
+- `docs/ROADMAP.md`의 Current Next Action이 P0.5 idle core creative rescue를 가리킨다.
+- 작업 종료 시 `items/<id>.md`, `docs/ROADMAP.md`, `docs/DASHBOARD.md`, GitHub issue/PR evidence를 갱신해야 한다는 지침이 문서화된다.
+- `npm run check:docs`, `npm run check:dashboard`, PR checks, main CI가 통과한다.
+
+## Evidence
+
+- Issue: #119
+- Verification:
+  - `npm run check:docs` — pass
+  - `npm run check:dashboard` — pass
+  - `npm run check:project-commands` — pass
+  - `npm run check:all` — pass
+
+## Apply Conditions
+
+- 게임 런타임/UI/에셋 구현은 이번 issue에서 하지 않는다.
+- 운영사 provider-portability/OMX 제거 확장은 이번 issue에서 하지 않는다.
+- 결제, 로그인, 광고, 외부 배포, 고객 데이터, 실채널 GTM은 건드리지 않는다.
+
+## Verification
+
+- `npm run check:docs`
+- PR checks
+- main CI


### PR DESCRIPTION
## Small win

P0.5 idle core + creative rescue 방향을 main source of truth로 고정합니다. 이제 다음 `$seed-ops`는 운영사 인프라가 아니라 production급 idle game core, UI, 에셋, visual QA를 하나의 vertical slice로 개선하는 방향을 따릅니다.

## Plan-first evidence

- Issue: #119
- Plan artifact: `items/0068-idle-core-creative-rescue-source-of-truth.md`

## 변경 요약

- `docs/IDLE_CORE_CREATIVE_GUIDE.md` 추가
  - idle game core loop
  - production UI 기준
  - asset bible
  - Codex vertical-slice workflow
- `docs/SESSION_HANDOFF_20260429.md` 추가
  - 새 Codex/OMX 세션 재개 순서
  - provider-portability 과설계 보류
  - 다음 게임 중심 작업 명시
- `docs/ROADMAP.md` 갱신
  - P0.5 Idle Core + Creative Rescue milestone 추가
  - Current Next Action을 P0.5 vertical slice 설계로 변경
- 작업 종료 문서 갱신 지침 추가
  - `docs/PROJECT_COMMANDS.md`
  - `docs/OPERATOR_RUNBOOK.md`
  - `AGENTS.md`
- `docs/DASHBOARD.md`는 `npm run update:dashboard`로 갱신

## Verification

- `npm run check:docs` — pass
- `npm run check:dashboard` — pass
- `npm run check:project-commands` — pass
- `npm run check:all` — pass

## Before / After 또는 Visual evidence

- N/A — 기획/source-of-truth 문서 변경이며 UI 변화 없음

## Playable mode

- N/A — 제품 코드 변경 없음. 기존 `npm run play:main` 유지.

## Risks

- 실제 P0.5 gameplay 구현은 후속 issue 범위입니다.
- 이번 PR은 기획/source-of-truth를 main에 고정하는 작업입니다.

Closes #119
