### PR TITLE
게임: P0.5 핵심 에셋 계획 추가

### DIFF
--- a/assets/source/asset_plan.json
+++ b/assets/source/asset_plan.json
@@ -3,8 +3,8 @@
   "project": "이상한 씨앗상회",
   "batch": {
     "id": "milestone1_style_validation_001",
-    "purpose": "Validate Codex native image generation for the first static game asset batch before Phase 0 implementation. Sprite batch 001 extends the proof with six starter spritesheet/fx strips.",
-    "target_asset_count": 26,
+    "purpose": "Validate Codex native image generation for static Phase 0 assets, starter sprite strips, and P0.5 production/order gameplay assets.",
+    "target_asset_count": 31,
     "generation_mode": "codex_native_image_generation",
     "runtime_generation_allowed": false
   },
@@ -469,6 +469,93 @@
         "greenhouse"
       ],
       "notes": "sprite_batch_001; strict_strip=true; frames=5; frame_width=96; frame_height=96; intended_frame_rate=12; loop=false; source_reference_asset_id=seed_herb_001_icon"
+    },
+    {
+      "id": "creature_herb_common_001_work",
+      "category": "creature",
+      "family": "herb",
+      "rarity": "common",
+      "growth_stage": "work",
+      "intended_use": "garden_work_state",
+      "output_path": "public/assets/game/creatures/states/creature_herb_common_001_work.png",
+      "manifest_tags": [
+        "phase0_5",
+        "creature",
+        "herb",
+        "common",
+        "work",
+        "production"
+      ],
+      "notes": "P0.5 state asset for 말랑잎 포리 producing leaves in the garden."
+    },
+    {
+      "id": "creature_herb_common_001_celebrate",
+      "category": "creature",
+      "family": "herb",
+      "rarity": "common",
+      "growth_stage": "celebrate",
+      "intended_use": "order_delivery_reward",
+      "output_path": "public/assets/game/creatures/states/creature_herb_common_001_celebrate.png",
+      "manifest_tags": [
+        "phase0_5",
+        "creature",
+        "herb",
+        "common",
+        "celebrate",
+        "order"
+      ],
+      "notes": "P0.5 state asset for 말랑잎 포리 celebrating first order delivery."
+    },
+    {
+      "id": "ui_order_crate_leaf_001",
+      "category": "ui_frame",
+      "family": "greenhouse",
+      "rarity": "common",
+      "growth_stage": "system",
+      "intended_use": "first_order_crate",
+      "output_path": "public/assets/game/ui/ui_order_crate_leaf_001.png",
+      "manifest_tags": [
+        "phase0_5",
+        "ui",
+        "order",
+        "crate",
+        "leaf"
+      ],
+      "notes": "Small order crate for the first leaf delivery commission."
+    },
+    {
+      "id": "fx_production_tick_leaf_001",
+      "category": "fx_strip",
+      "family": "greenhouse",
+      "rarity": "common",
+      "growth_stage": "system",
+      "intended_use": "production_tick_fx",
+      "output_path": "public/assets/game/fx/fx_production_tick_leaf_001_strip.png",
+      "manifest_tags": [
+        "phase0_5",
+        "fx",
+        "production",
+        "leaf",
+        "tick"
+      ],
+      "notes": "Small leaf pop effect for automatic production tick."
+    },
+    {
+      "id": "fx_order_delivery_burst_001",
+      "category": "fx_strip",
+      "family": "greenhouse",
+      "rarity": "common",
+      "growth_stage": "system",
+      "intended_use": "order_delivery_reward_fx",
+      "output_path": "public/assets/game/fx/fx_order_delivery_burst_001_strip.png",
+      "manifest_tags": [
+        "phase0_5",
+        "fx",
+        "order",
+        "delivery",
+        "reward"
+      ],
+      "notes": "Reward burst effect for first order delivery."
     }
   ]
 }

--- a/assets/source/asset_prompts.json
+++ b/assets/source/asset_prompts.json
@@ -316,6 +316,66 @@
         "readable at 96px with no text, watermark, logo, or background clutter",
         "runtime generation remains disabled and output is saved in the workspace"
       ]
+    },
+    {
+      "asset_id": "creature_herb_common_001_work",
+      "output_path": "public/assets/game/creatures/states/creature_herb_common_001_work.png",
+      "prompt": "Use case: stylized-concept\nAsset type: idle web game creature work-state asset\nPrimary request: Create a work-state version of 말랑잎 포리 for 이상한 씨앗상회.\nSubject: The same small round leafy gatherer creature, gently working in the garden with a leaf satchel open, tiny leaves floating upward, focused but cute expression.\nStyle/medium: Cute-strange greenhouse collectible style, polished 2D game art, soft rounded shapes, crisp readable silhouette, subtle painterly texture, bright but not neon colors, mobile idle game asset, clean edges, no text, no watermark.\nComposition/framing: Centered full-body character, transparent or clean removable background, generous padding, readable at 64px and 96px.\nColor palette: Fresh herb greens, warm leaf yellow, cream face accents, deep greenhouse teal details.\nConstraints: Match the existing 말랑잎 포리 identity, no text, no watermark, no logo, no busy background, no runtime generation reference.\nAvoid: New unrelated character design, copyrighted resemblance, photorealism, horror, excessive tiny props.",
+      "acceptance": [
+        "transparent or clean removable background",
+        "readable at 64px and 96px",
+        "matches existing Herb/말랑잎 포리 identity",
+        "no text, watermark, logo, or copyrighted resemblance",
+        "suitable for garden UI state use"
+      ]
+    },
+    {
+      "asset_id": "creature_herb_common_001_celebrate",
+      "output_path": "public/assets/game/creatures/states/creature_herb_common_001_celebrate.png",
+      "prompt": "Use case: stylized-concept\nAsset type: idle web game creature celebrate-state asset\nPrimary request: Create a celebrate-state version of 말랑잎 포리 for first order delivery.\nSubject: The same leafy gatherer creature happily jumping with a tiny leaf satchel and soft reward sparkle, celebrating a delivery without holding readable signs.\nStyle/medium: Cute-strange greenhouse collectible style, polished 2D game art, soft rounded shapes, crisp readable silhouette, subtle painterly texture, bright but not neon colors, mobile idle game asset, clean edges, no text, no watermark.\nComposition/framing: Centered full-body character, transparent or clean removable background, generous padding, readable at 64px and 96px.\nColor palette: Fresh herb greens, warm leaf yellow, cream highlights, small golden reward sparkle accents.\nConstraints: Must feel like the same creature as creature_herb_common_001, no text, no watermark, no logo, no busy background.\nAvoid: Confetti text, brand-like symbols, unrelated costume, copyrighted resemblance, overcomplex particle clutter.",
+      "acceptance": [
+        "transparent or clean removable background",
+        "readable at 64px and 96px",
+        "matches existing Herb/말랑잎 포리 identity",
+        "no text, watermark, logo, or copyrighted resemblance",
+        "suitable for garden UI state use"
+      ]
+    },
+    {
+      "asset_id": "ui_order_crate_leaf_001",
+      "output_path": "public/assets/game/ui/ui_order_crate_leaf_001.png",
+      "prompt": "Use case: stylized-concept\nAsset type: idle web game order crate UI image\nPrimary request: Create a small leaf delivery order crate for the first commission.\nSubject: A cute wooden greenhouse crate with leafy produce tucked inside, a simple leaf emblem shape without text, soft cloth lining, and a friendly game UI silhouette.\nStyle/medium: Cute-strange greenhouse collectible style, polished 2D game art, soft rounded shapes, crisp readable silhouette, subtle painterly texture, bright but not neon colors, mobile idle game asset, clean edges, no text, no watermark.\nComposition/framing: Centered object icon, transparent or clean removable background, generous padding, readable at 48px and 96px.\nColor palette: Warm wood brown, fresh leaf green, cream cloth, soft yellow highlights.\nConstraints: No readable text, no logo, no watermark, no real brand mark, no payment or loot-box cue.\nAvoid: Shipping company symbols, text labels, photorealistic crate, cluttered produce pile, dark low-contrast shape.",
+      "acceptance": [
+        "transparent or clean removable background",
+        "readable at 48px and 96px",
+        "no readable text, watermark, logo, or brand mark",
+        "clearly communicates first leaf order",
+        "does not resemble payment or loot-box UI"
+      ]
+    },
+    {
+      "asset_id": "fx_production_tick_leaf_001",
+      "output_path": "public/assets/game/fx/fx_production_tick_leaf_001_strip.png",
+      "prompt": "Use case: stylized-concept\nAsset type: idle web game production tick FX strip\nPrimary request: Create a simple leaf production tick effect as a horizontal sprite strip concept.\nSubject: Four small frames of a leaf pop: tiny leaf appears, rises, sparkles softly, fades.\nStyle/medium: Cute-strange greenhouse collectible style, polished 2D game art, soft rounded shapes, crisp readable silhouette, subtle painterly texture, bright but not neon colors, mobile idle game asset, clean edges, no text, no watermark.\nComposition/framing: Horizontal strip layout with four evenly spaced frames on transparent or clean removable background, generous padding around each frame.\nColor palette: Fresh leaf green, warm yellow highlight, cream sparkle.\nConstraints: No text, no watermark, no logo, no character, readable at small HUD size, each frame separated visually.\nAvoid: Busy particles, realistic falling leaves, brand symbols, dark glow, complex background.",
+      "acceptance": [
+        "transparent or clean removable background",
+        "four-frame horizontal strip concept is clear",
+        "readable at small HUD/playfield size",
+        "no text, watermark, logo, or money/casino cue",
+        "matches warm greenhouse reward style"
+      ]
+    },
+    {
+      "asset_id": "fx_order_delivery_burst_001",
+      "output_path": "public/assets/game/fx/fx_order_delivery_burst_001_strip.png",
+      "prompt": "Use case: stylized-concept\nAsset type: idle web game order delivery reward FX strip\nPrimary request: Create a reward burst effect for first order delivery as a horizontal sprite strip concept.\nSubject: Four small frames of a soft golden-green burst: closed bud spark, expanding ring, leaf sparkle pop, gentle fade.\nStyle/medium: Cute-strange greenhouse collectible style, polished 2D game art, soft rounded shapes, crisp readable silhouette, subtle painterly texture, bright but not neon colors, mobile idle game asset, clean edges, no text, no watermark.\nComposition/framing: Horizontal strip layout with four evenly spaced frames on transparent or clean removable background, readable at 64px.\nColor palette: Warm reward gold, fresh green, cream sparkle, tiny teal accent.\nConstraints: No text, no watermark, no logo, no coin/cash symbol, no casino-like cue.\nAvoid: Fireworks clutter, real money symbols, brand-like icon, harsh neon, dark low contrast.",
+      "acceptance": [
+        "transparent or clean removable background",
+        "four-frame horizontal strip concept is clear",
+        "readable at small HUD/playfield size",
+        "no text, watermark, logo, or money/casino cue",
+        "matches warm greenhouse reward style"
+      ]
     }
   ]
 }

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -38,9 +38,9 @@ Updated: 2026-04-29
 
 | 상태 | 개수 |
 | --- | ---: |
-| done | 42 |
-| review | 62 |
-| todo | 3 |
+| done | 43 |
+| review | 61 |
+| todo | 2 |
 | blocked | 0 |
 
 ## 다음 작업

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,8 +27,8 @@ Goal: 현재 수집 UI 프로토타입을 production급 idle collection tycoon v
 | Idle core creative guide | active | `docs/IDLE_CORE_CREATIVE_GUIDE.md`, `docs/SESSION_HANDOFF_20260429.md` | Egg, Inc./Idle Miner/Cell to Singularity에서 배운 생산 엔진, 장기 메타, asset bible, Codex vertical-slice workflow가 문서화됨 |
 | Creature role + auto production v0 | done | Issue #121, PR #122, `items/0069-idle-production-order-v0.md`, production tick UI, visual evidence, main CI `25090571222` | 첫 생명체가 정원 경제에 참여하고 생산 tick이 화면에서 읽힘 |
 | Order/commission v0 | done | Issue #121, PR #122, `items/0069-idle-production-order-v0.md`, first order UI, reward loop, visual evidence, main CI `25090571222` | 짧은 주문 목표가 생기고 납품 보상이 다음 씨앗/연구/탐험 목표로 이어짐 |
-| Production garden UI v0 | review | Issue #123, `items/0070-production-garden-ui-v0.md`, compact production/order UI, visual evidence | 정원 화면이 패널 앱이 아니라 생산 엔진이 보이는 모바일 게임 화면처럼 읽힘 |
-| Core asset batch v0 | todo | creature work/celebrate, order crate, reward FX, manifest | gameplay role이 있는 asset batch가 투명 배경/작은 크기 판독성/manifest 검증을 통과함 |
+| Production garden UI v0 | done | Issue #123, PR #124, `items/0070-production-garden-ui-v0.md`, compact production/order UI, visual evidence, main CI `25090930573` | 정원 화면이 패널 앱이 아니라 생산 엔진이 보이는 모바일 게임 화면처럼 읽힘 |
+| Core asset batch v0 | active | Issue #125, `items/0071-core-asset-batch-plan.md`, P0.5 asset plan/prompts | gameplay role이 있는 asset batch가 투명 배경/작은 크기 판독성/manifest 검증을 통과함 |
 
 ## P0 Game Studio Operating Mode — UI/UX Rescue
 
@@ -251,8 +251,8 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 즉시 다음 작업:
 
-1. Issue #123 / `items/0070-production-garden-ui-v0.md`를 PR/CI/main merge까지 닫는다.
-2. 다음 `$seed-ops` issue는 `Core asset batch v0`로 plan-first 작성한다.
+1. Issue #125 / `items/0071-core-asset-batch-plan.md`를 PR/CI/main merge까지 닫는다.
+2. 다음 `$seed-ops` issue는 P0.5 core asset generation/review/manifest integration으로 plan-first 작성한다.
 3. 다음 구현 PR도 게임 core, UI, 에셋, visual QA를 분리하지 않는 작은 vertical slice로 만든다.
 4. 운영사 인프라는 CI/QA/상태 이해가 게임 개발을 막을 때만 우선한다.
 

--- a/items/0070-production-garden-ui-v0.md
+++ b/items/0070-production-garden-ui-v0.md
@@ -1,6 +1,6 @@
 # Production garden UI v0
 
-Status: review
+Status: done
 Work type: game_feature
 Issue: #123
 Owner: agent
@@ -59,6 +59,9 @@ P0.5 idle core creative rescue의 두 번째 구현 slice다. #121에서 자동 
 ## Evidence
 
 - Issue: #123
+- PR: #124
+- Merge commit: `f0a0ac730d17d10178d605d614f041e686c7b507`
+- Main CI: `25090930573` — pass
 - Branch: `codex/0070-production-garden-ui-v0`
 - Visual evidence: `reports/visual/p0-production-garden-ui-v0-20260429.md`
 - Verification:

--- a/items/0071-core-asset-batch-plan.md
+++ b/items/0071-core-asset-batch-plan.md
@@ -1,0 +1,78 @@
+# Core asset batch v0 plan
+
+Status: review
+Work type: game_content
+Issue: #125
+Owner: agent
+Created: 2026-04-29
+Updated: 2026-04-29
+Scope-risk: narrow
+
+## Intent
+
+P0.5 idle core creative rescue에서 자동 생산과 첫 주문 루프가 생겼지만, 아직 생명체가 일하거나 납품을 축하하는 asset이 없다. 이번 issue는 이미지 생성 전에 필요한 core gameplay asset 계획과 prompt batch를 기존 asset source of truth에 추가한다.
+
+## Small win
+
+`assets/source/asset_plan.json`과 `assets/source/asset_prompts.json`이 P0.5 생산/주문 asset batch를 포함하고, 다음 issue가 바로 Codex native image generation으로 이어질 수 있다.
+
+## Asset Target
+
+- `creature_herb_common_001_work`: 말랑잎 포리 작업 상태
+- `creature_herb_common_001_celebrate`: 말랑잎 포리 납품/보상 축하 상태
+- `ui_order_crate_leaf_001`: 첫 잎 주문 상자
+- `fx_production_tick_leaf_001`: 생산 tick FX
+- `fx_order_delivery_burst_001`: 주문 납품 reward FX
+
+## Plan
+
+1. 기존 asset plan/prompts 구조를 보존하고 새 P0.5 batch asset만 추가한다.
+2. 모든 output path는 기존 accepted asset을 덮어쓰지 않는 새 경로로 둔다.
+3. 각 prompt는 투명 배경, 작은 크기 판독성, no text/no watermark/no logo를 포함한다.
+4. 생성은 이번 issue에서 하지 않고, 후속 issue에서 `gpt-game-asset-generate` workflow로 진행한다.
+5. JSON parse, id 중복, prompt/plan 일치 검증을 추가하거나 기존 명령으로 확인한다.
+6. `docs/ROADMAP.md`, `docs/DASHBOARD.md`를 갱신한다.
+
+## Acceptance Criteria
+
+- P0.5 core asset 5개가 `assets/source/asset_plan.json`에 추가된다.
+- 같은 5개가 `assets/source/asset_prompts.json`에 추가되고 prompt count가 asset count와 일치한다.
+- 기존 accepted asset output path를 덮어쓰지 않는다.
+- runtime image generation 경로를 추가하지 않는다.
+- 다음 issue가 이미지 생성/검수/manifest 통합을 바로 시작할 수 있다.
+
+## Verification
+
+- `node -e` JSON parse/check
+- `npm run check:content`
+- `npm run check:asset-alpha`
+- `npm run check:all`
+- `npm run update:dashboard`
+- `npm run check:dashboard`
+
+## Risks
+
+- `asset_plan.json`이 이미 milestone1 batch까지 포함하므로 무분별한 재작성은 이전 pipeline 증거를 흐릴 수 있다. 이번 변경은 append-only로 유지한다.
+- 실제 생성 전이므로 `Core asset batch v0`는 아직 완료가 아니다. 생성/검수/manifest 통합은 후속 issue로 남긴다.
+
+## Apply Conditions
+
+- 기존 accepted asset 파일은 덮어쓰지 않는다.
+- 새 dependency를 추가하지 않는다.
+- 런타임 이미지 생성, 결제, 로그인, 광고, 외부 배포는 금지한다.
+
+## Evidence
+
+- Issue: #125
+- Branch: `codex/0071-core-asset-batch-plan`
+- Asset plan count: 31
+- Prompt count: 31
+- Added asset ids:
+  - `creature_herb_common_001_work`
+  - `creature_herb_common_001_celebrate`
+  - `ui_order_crate_leaf_001`
+  - `fx_production_tick_leaf_001`
+  - `fx_order_delivery_burst_001`
+- Verification:
+  - `node -e` JSON parse/id/prompt/path check — pass
+  - `npm run check:all` — pass


### PR DESCRIPTION
## 요약

- P0.5 idle core에 필요한 첫 static asset batch 계획과 prompt 5개를 추가했습니다.
- 추가 asset은 creature work/celebrate, order crate, production tick FX, delivery burst FX입니다.
- plan/prompt id 정합성, 출력 파일명 중복, 전체 repo check를 검증했습니다.

## Small win

- 이번 PR이 만든 가장 작은 승리: 다음 issue에서 바로 생성/리뷰할 수 있는 P0.5 core asset 작업 단위가 생겼습니다.

## Plan-first evidence

- Plan artifact: `items/0071-core-asset-batch-plan.md`
- Plan에서 벗어난 변경이 있다면 이유: 없음. 실제 이미지 생성은 후속 issue #127로 분리했습니다.

## 작업 checklist

- [x] Plan artifact의 수용 기준을 모두 확인했다.
- [x] UI/visual 변경이면 Browser Use 우선 QA를 시도하고 evidence 또는 blocker를 남겼다.
- [x] 필요한 문서/roadmap/dashboard/report를 갱신했다.
- [x] GitHub issue/PR/comment evidence를 축약 없이 남겼다.

## 사용자/운영자 가치

- 게임 가치: 생산/주문 루프가 text UI에 머무르지 않고 creature motion, crate, reward FX로 발전할 준비가 됐습니다.
- 운영사 가치: runtime image generation 없이 source plan/prompt를 먼저 고정해 static asset pipeline을 추적 가능하게 유지합니다.

## Before / After 또는 Visual evidence

- Before: `assets/source/asset_plan.json`과 `assets/source/asset_prompts.json`은 26개 항목이었고 P0.5 생산/주문 asset이 부족했습니다.
- After: 두 파일 모두 31개 항목이며 P0.5 core asset id 5개가 추가됐습니다.
- Browser Use evidence 또는 blocker: N/A. 런타임 UI 변경이 없는 source asset plan/prompt PR입니다.
- N/A 사유: 이미지 생성/화면 변경이 아닌 source metadata PR입니다.

## Playable mode

- main 실행 명령: `npm run play:main` 후 필요 시 `npm run play:main:install`, 그리고 `cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174`
- 이 PR이 사람 플레이 환경을 막지 않는 이유: runtime code와 shipped public asset을 바꾸지 않는 source plan/prompt 변경입니다.

## 검증

- [x] `npm run check:all` PASS
- [x] UI/visual 변경이면 Browser Use QA 또는 명시 blocker + Playwright/CDP fallback PASS
- [x] Node JSON/id/output filename consistency check PASS
- [x] PR checks PASS: Check automerge eligibility, Verify game baseline
- [x] main CI PASS: run `25091264618`

## 안전 범위

- [x] 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음
- [x] `ENABLE_AGENT_AUTOMERGE` 변경 없음
- [x] Branch protection 우회 없음

## 남은 위험

- 실제 bitmap 품질, alpha 처리, manifest 연결은 후속 생성/리뷰 issue #127에서 확인해야 합니다.
- 생성 asset이 small-size readability를 만족하지 못하면 prompt 또는 crop 기준을 조정해야 합니다.

## 연결된 issue

Closes #125
