### PR TITLE
운영: 닫힌 issue roadmap 상태 동기화 #156

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -27,7 +27,7 @@ Updated: 2026-04-29
 | 운영사 2h readiness | review | `npm run operator:trial:readiness` |
 | 운영 상황판 | review | `docs/OPERATOR_CONTROL_ROOM.md`, `npm run check:control-room` |
 | 운영 루프 지속성 | done | Issue #115, `npm run check:operator` |
-| 프로젝트 명령어 | active | `docs/PROJECT_COMMANDS.md`, `npm run check:project-commands` |
+| 프로젝트 명령어 | done | `docs/PROJECT_COMMANDS.md`, `npm run check:project-commands` |
 | 사람 플레이 모드 | verified | `npm run play:main`, port 5174 |
 | Sprite batch QA gate | review | `npm run check:sprite-batch` |
 | 플레이테스트 intake | review | `npm run check:playtest-intake` |
@@ -38,7 +38,7 @@ Updated: 2026-04-29
 
 | 상태 | 개수 |
 | --- | ---: |
-| done | 50 |
+| done | 55 |
 | review | 62 |
 | todo | 2 |
 | blocked | 0 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,14 +30,14 @@ Goal: 현재 수집 UI 프로토타입을 production급 idle collection tycoon v
 | Production garden UI v0 | done | Issue #123, PR #124, `items/0070-production-garden-ui-v0.md`, compact production/order UI, visual evidence, main CI `25090930573` | 정원 화면이 패널 앱이 아니라 생산 엔진이 보이는 모바일 게임 화면처럼 읽힘 |
 | Core asset batch v0 | active | Issue #125 closed, PR #126, Issue #127, Issue #131, `items/0071-core-asset-batch-plan.md`, `items/0072-core-asset-generation-first-pass.md`, `items/0074-core-asset-manifest-normalization.md`, P0.5 generated candidates and manifest entries | gameplay role이 있는 asset batch가 투명 배경/작은 크기 판독성/manifest 검증을 통과함 |
 | Production/order asset runtime v0 | done | Issue #133, PR #134, `items/0075-production-order-asset-runtime-v0.md`, Browser Use QA, visual gate, main CI `25094604445` | 첫 생산/주문 UI에서 work creature, order crate, celebrate state가 보이고 모바일 첫 화면 밀도가 유지됨 |
-| Production/order FX runtime v0 | active | Issue #135, `items/0076-production-order-fx-runtime-v0.md`, Browser Use QA, visual gate | 생산 수령/주문 납품 순간에 static FX strip feedback이 보이고 Phaser board 세로줄 artifact가 줄어듦 |
+| Production/order FX runtime v0 | done | Issue #135, `items/0076-production-order-fx-runtime-v0.md`, Browser Use QA, `reports/visual/p0-production-order-fx-runtime-20260429.md` | 생산 수령/주문 납품 순간에 static FX strip feedback이 보이고 Phaser board 세로줄 artifact가 줄어듦 |
 | Playfield production actors v0 | done | Issue #144, `items/0082-playfield-production-actors-v0.md`, Browser Use QA, `reports/visual/p0-playfield-production-actors-v0-20260429.md` | 정원 playfield 안에 work creature, order crate, order progress가 보여 production engine이 board scene으로 읽힘 |
 | Upgrade choice surface v0 | done | Issue #146, `items/0083-upgrade-choice-surface-v0.md`, Browser Use QA, `reports/visual/p0-upgrade-choice-surface-v0-20260429.md` | 생산/주문 보상 아래에 밭 확장, 생산 속도, 주문 준비 선택이 보여 idle tycoon 성장 방향이 읽힘 |
 | Production speed upgrade loop v0 | done | Issue #148, `items/0084-production-speed-upgrade-loop-v0.md`, Browser Use QA, `reports/visual/p0-production-speed-upgrade-loop-v0-20260429.md` | 첫 주문 납품 보상이 작업 간식 강화로 이어지고 production rate가 7.2 -> 9.0으로 상승함 |
 | Repeat order v0 | done | Issue #150, `items/0085-repeat-order-v0.md`, Browser Use QA, `reports/visual/p0-repeat-order-v0-20260429.md` | 첫 주문 후 `연구 준비 잎 묶음`이 다음 주문으로 등장하고 생산 수령이 새 주문 진행률을 채움 |
 | Research unlock v0 | done | Issue #152, `items/0086-research-unlock-v0.md`, Browser Use QA, `reports/visual/p0-research-unlock-v0-20260429.md` | 두 번째 주문 보상이 `새싹 기록법 연구` purchase와 `researchLevel` 저장으로 이어짐 |
 | Research clue reward v0 | done | Issue #154, `items/0087-research-clue-reward-v0.md`, Browser Use QA, `reports/visual/p0-research-clue-reward-v0-20260429.md` | 연구 완료가 다음 생명체/씨앗 단서로 이어져 수집 목표가 더 명확해짐 |
-| Playfield board readability v0 | active | Issue #137, `items/0077-playfield-board-readability-v0.md`, Browser Use QA, visual gate | 세로줄 artifact 완화 후에도 plot/status text가 읽히고 locked plot 반복 노이즈가 줄어듦 |
+| Playfield board readability v0 | done | Issue #137, `items/0077-playfield-board-readability-v0.md`, Browser Use QA, `reports/visual/p0-playfield-board-readability-20260429.md` | 세로줄 artifact 완화 후에도 plot/status text가 읽히고 locked plot 반복 노이즈가 줄어듦 |
 
 ## P0 Game Studio Operating Mode — UI/UX Rescue
 
@@ -45,9 +45,9 @@ Goal: P0가 단순히 기능이 돌아가는 상태가 아니라, 첫 화면이 
 
 | Step | Status | Output | Acceptance Criteria |
 | --- | --- | --- | --- |
-| P0 UI/UX research baseline | active | `docs/GAME_UI_UX_RESEARCH_20260428.md`, `items/0053-game-ui-ux-p0-rescue.md`, Issue #89 | HUD/playfield, Phaser viewport, CLI visual QA, alpha asset 기준과 프로젝트 결정이 문서화됨 |
+| P0 UI/UX research baseline | done | `docs/GAME_UI_UX_RESEARCH_20260428.md`, `items/0053-game-ui-ux-p0-rescue.md`, Issue #89 | HUD/playfield, Phaser viewport, CLI visual QA, alpha asset 기준과 프로젝트 결정이 문서화됨 |
 | Playfield-first garden screen | active | `src/App.tsx`, `src/styles.css`, `src/game/playfield/GardenScene.ts` | 정원 기본 화면에서 안내/하이라이트/패널이 밭을 가리지 않고 Phaser playfield가 주 시각 영역으로 보임 |
-| Garden action surface v0 | active | Issue #140, `items/0080-garden-action-surface-v0.md`, `src/App.tsx`, `src/styles.css`, visual evidence | 정원 기본 화면의 하단 UI가 작은 스크롤 패널이 아니라 primary CTA와 compact goal strip 중심의 game action surface로 읽힘 |
+| Garden action surface v0 | done | Issue #140, `items/0080-garden-action-surface-v0.md`, `src/App.tsx`, `src/styles.css`, `reports/visual/p0-garden-action-surface-v0-20260429.md` | 정원 기본 화면의 하단 UI가 작은 스크롤 패널이 아니라 primary CTA와 compact goal strip 중심의 game action surface로 읽힘 |
 | Phaser playfield presentation polish | done | Issue #99, PR #100, `items/0058-playfield-presentation-polish.md`, `src/game/playfield/GardenScene.ts` | ready/locked/empty plot 상태가 모바일 수집 게임 화면처럼 더 선명하게 구분되고 main CI가 통과함 |
 | Phaser playfield visual-noise cleanup | done | Issue #101, PR #102, `items/0059-playfield-visual-noise-cleanup.md`, `src/game/playfield/GardenScene.ts` | locked plot 반복 텍스트/강한 선을 줄이고 main CI가 통과함 |
 | Player/debug surface split | active | app shell/debug mode policy | `asset count`, `save ready`, `events`, `runtime image generation disabled`는 playable 기본 화면에서 숨겨지고 debug mode에서만 노출됨 |
@@ -234,7 +234,7 @@ Goal: run for multiple hours under supervision with budget, safety gates, and re
 | Add operator control room and playable mode | review | Issue #87, `docs/OPERATOR_CONTROL_ROOM.md`, `docs/PLAYABLE_MODE.md`, `.github/ISSUE_TEMPLATE/agent-work-item.md`, `.github/pull_request_template.md`, `scripts/prepare-playable-main.mjs`, `items/0052-operator-control-room-playable-mode.md` | 사람이 active mission, small win, visual evidence, PR/issue, playable main command를 한 화면에서 파악하고 agent 작업 중에도 게임을 실행할 수 있음 |
 | Issue-level plan-first gate | done | Issue #106, PR #107, `items/0061-issue-plan-first-operating-rule.md`, operator docs/checker | 모든 issue/work-item 단위 작업은 개발 전에 `## Plan` artifact를 만들고 검증 계획을 기록해야 하며 main CI가 통과함 |
 | Operator continuation watchdog | done | Issue #115, PR #116, `items/0066-operator-continuation-watchdog.md`, `reports/operations/operator-continuation-watchdog-20260429.md`, main CI `25085732384` | 완료 보고는 중단 조건이 아니라 체크포인트이며, 명시 중단/시간 상한/외부 승인/치명적 blocker가 없으면 다음 issue를 plan-first로 선택함 |
-| Project command surface | active | Issue #117, `items/0067-project-command-surface.md`, `docs/PROJECT_COMMANDS.md`, `.codex/skills/seed-*` | `$seed-ops`, `$seed-brief`, `$seed-design`, `$seed-qa`, `$seed-play`로 운영 루프와 대화/보고/QA/playable 세션을 구분함 |
+| Project command surface | done | Issue #117, `items/0067-project-command-surface.md`, `docs/PROJECT_COMMANDS.md`, `.codex/skills/seed-*` | `$seed-ops`, `$seed-brief`, `$seed-design`, `$seed-qa`, `$seed-play`로 운영 루프와 대화/보고/QA/playable 세션을 구분함 |
 
 ## Milestone 8: Feedback + GTM Mock Intake
 

--- a/items/0053-game-ui-ux-p0-rescue.md
+++ b/items/0053-game-ui-ux-p0-rescue.md
@@ -1,6 +1,6 @@
 # P0 Game UI/UX rescue와 CLI 실기 QA 게이트
 
-Status: in_progress
+Status: completed
 Owner: agent
 Created: 2026-04-28
 Updated: 2026-04-28
@@ -25,6 +25,7 @@ Branch: codex/p0-game-ui-ux-rescue
 
 ## Evidence
 
+- Issue #89: CLOSED
 - Visual report: `reports/visual/p0-ui-ux-rescue-20260428.md`
 - Before mobile: `reports/visual/p0-ui-ux-before-main-mobile-20260428.png`
 - After mobile: `reports/visual/p0-ui-ux-after-mobile-20260428.png`

--- a/items/0067-project-command-surface.md
+++ b/items/0067-project-command-surface.md
@@ -1,6 +1,6 @@
 # Project command surface
 
-Status: active
+Status: completed
 Work type: agent_ops
 Issue: #117
 Owner: agent
@@ -34,6 +34,7 @@ Scope-risk: narrow
 ## Evidence
 
 - Issue: #117
+- GitHub state: CLOSED
 - Verification:
   - `npm run check:project-commands` — pass
   - `npm run check:docs` — pass

--- a/items/0076-production-order-fx-runtime-v0.md
+++ b/items/0076-production-order-fx-runtime-v0.md
@@ -1,6 +1,6 @@
 # Production order FX runtime v0
 
-Status: active
+Status: completed
 Issue: #135
 Branch: `codex/0076-production-order-fx-runtime-v0`
 Date: 2026-04-29
@@ -24,10 +24,16 @@ Date: 2026-04-29
 
 ## Acceptance Criteria
 
-- 생산 수령 클릭 후 `fx_production_tick_leaf_001_strip` 기반 FX가 한 번 보인다.
-- 첫 주문 납품 클릭 후 `fx_order_delivery_burst_001_strip` 기반 FX가 한 번 보인다.
-- 모바일 정원 첫 화면에서 next goal과 bottom tab overlap이 없다.
-- runtime image generation, 새 dependency, 저장/content/economy 계약 변경이 없다.
+- [x] 생산 수령 클릭 후 `fx_production_tick_leaf_001_strip` 기반 FX가 한 번 보인다.
+- [x] 첫 주문 납품 클릭 후 `fx_order_delivery_burst_001_strip` 기반 FX가 한 번 보인다.
+- [x] 모바일 정원 첫 화면에서 next goal과 bottom tab overlap이 없다.
+- [x] runtime image generation, 새 dependency, 저장/content/economy 계약 변경이 없다.
+
+## Evidence
+
+- Issue #135: CLOSED
+- Visual report: `reports/visual/p0-production-order-fx-runtime-20260429.md`
+- Browser Use: `reports/visual/p0-production-order-fx-runtime-browser-use-20260429.png`
 
 ## Verification Commands
 

--- a/items/0077-playfield-board-readability-v0.md
+++ b/items/0077-playfield-board-readability-v0.md
@@ -1,6 +1,6 @@
 # Playfield board readability v0
 
-Status: active
+Status: completed
 Issue: #137
 Branch: `codex/0077-playfield-board-readability-v0`
 Date: 2026-04-29
@@ -22,10 +22,16 @@ Date: 2026-04-29
 
 ## Acceptance Criteria
 
-- Browser Use 화면에서 playfield 세로줄이 다시 두드러지지 않는다.
-- plot state text와 생산 status text가 모바일 첫 화면에서 읽힌다.
-- bottom tab과 next goal overlap이 없다.
-- 저장/content/economy/runtime asset 계약 변경이 없다.
+- [x] Browser Use 화면에서 playfield 세로줄이 다시 두드러지지 않는다.
+- [x] plot state text와 생산 status text가 모바일 첫 화면에서 읽힌다.
+- [x] bottom tab과 next goal overlap이 없다.
+- [x] 저장/content/economy/runtime asset 계약 변경이 없다.
+
+## Evidence
+
+- Issue #137: CLOSED
+- Visual report: `reports/visual/p0-playfield-board-readability-20260429.md`
+- Browser Use: `reports/visual/p0-playfield-board-readability-browser-use-20260429.png`
 
 ## Verification Commands
 

--- a/items/0080-garden-action-surface-v0.md
+++ b/items/0080-garden-action-surface-v0.md
@@ -1,6 +1,6 @@
 # Garden action surface v0
 
-Status: active
+Status: completed
 Work type: game_ui
 Branch: `codex/0080-garden-action-surface-v0`
 Date: 2026-04-29
@@ -35,12 +35,18 @@ Issue: #140
 
 ## 수용 기준
 
-- 모바일 정원 기본 화면에서 `starter-panel` 내부 스크롤이 생기지 않는다.
-- `?qaProductionReady=1`에서 자동 생산/첫 주문 상태가 흐린 작은 카드가 아니라 action surface의 주 동사로 읽힌다.
-- 정원 첫 화면에서 primary CTA가 하나 이상 44px 이상 터치 영역으로 보인다.
-- 다음 생명체 목표는 보조 compact strip으로 보이며 playfield와 CTA를 밀어내지 않는다.
-- Phaser playfield의 input/runtime 계약과 save/economy/content 계약을 바꾸지 않는다.
-- Browser Use evidence와 `npm run check:visual`, `npm run check:ci`가 통과한다.
+- [x] 모바일 정원 기본 화면에서 `starter-panel` 내부 스크롤이 생기지 않는다.
+- [x] `?qaProductionReady=1`에서 자동 생산/첫 주문 상태가 흐린 작은 카드가 아니라 action surface의 주 동사로 읽힌다.
+- [x] 정원 첫 화면에서 primary CTA가 하나 이상 44px 이상 터치 영역으로 보인다.
+- [x] 다음 생명체 목표는 보조 compact strip으로 보이며 playfield와 CTA를 밀어내지 않는다.
+- [x] Phaser playfield의 input/runtime 계약과 save/economy/content 계약을 바꾸지 않는다.
+- [x] Browser Use evidence와 `npm run check:visual`, `npm run check:ci`가 통과한다.
+
+## Evidence
+
+- Issue #140: CLOSED
+- Visual report: `reports/visual/p0-garden-action-surface-v0-20260429.md`
+- Browser Use target: `http://127.0.0.1:5175/?qaProductionReady=1`
 
 ## 검증 명령
 

--- a/items/0088-roadmap-closed-issue-sync-v0.md
+++ b/items/0088-roadmap-closed-issue-sync-v0.md
@@ -1,0 +1,42 @@
+# Roadmap closed issue sync v0
+
+Status: completed
+Work type: agent_ops
+Branch: `codex/0088-roadmap-closed-issue-sync-v0`
+Date: 2026-04-29
+Issue: #156
+
+## 문제 / 배경
+
+`docs/ROADMAP.md`에 active로 남은 항목 중 GitHub issue가 이미 CLOSED인 항목이 있었다. 이 상태는 `$seed-ops`가 다음 작업을 고를 때 닫힌 issue를 다시 후보처럼 보는 문제를 만든다.
+
+## Small win
+
+다음 issue 선택에서 이미 닫힌 #135/#137/#140/#117/#89가 active 후보처럼 보이지 않는다.
+
+## Plan
+
+1. GitHub에서 active roadmap issue들의 CLOSED/OPEN 상태를 확인한다.
+2. CLOSED issue와 연결된 roadmap row를 `done`으로 바꾼다.
+3. 연결 item의 `Status`를 `completed`로 바꾸고 evidence/report 링크를 추가한다.
+4. `npm run update:dashboard`, `npm run check:ci`로 검증한다.
+
+## 수용 기준
+
+- [x] Issue #135, #137, #140, #117, #89의 GitHub CLOSED 상태를 확인했다.
+- [x] 해당 roadmap rows가 더 이상 active가 아니다.
+- [x] 연결 item status와 evidence가 완료 상태를 반영한다.
+- [x] dashboard가 재생성됐다.
+- [x] `npm run check:ci`가 통과한다.
+
+## 검증 명령
+
+- [x] `npm run update:dashboard`
+- [x] `npm run check:ci`
+
+## 안전 범위
+
+- runtime code 변경 없음.
+- 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음.
+- 새 dependency 없음.
+- runtime image generation 없음.

--- a/scripts/check-project-commands.mjs
+++ b/scripts/check-project-commands.mjs
@@ -57,7 +57,7 @@ requirePhrases("docs/PROJECT_COMMANDS.md", [
 ]);
 
 requirePhrases("items/0067-project-command-surface.md", [
-  "Status: active",
+  "Status: completed",
   "Work type: agent_ops",
   "Issue: #117",
   "## Plan",


### PR DESCRIPTION
## 요약

- GitHub에서 이미 CLOSED인 #135, #137, #140, #117, #89가 roadmap/item에서 active처럼 남아 있던 상태를 완료로 정리했습니다.
- `Project command surface` 검증 스크립트가 닫힌 item을 여전히 `Status: active`로 요구하던 stale gate를 `completed` 기준으로 수정했습니다.
- `docs/DASHBOARD.md`를 재생성하고 #156 plan artifact에 수용 기준 완료 evidence를 남겼습니다.

## Small win

- 이번 PR이 만든 가장 작은 승리: `$seed-ops`가 다음 작업을 고를 때 이미 닫힌 issue를 active 후보처럼 다시 보지 않습니다.

## Plan-first evidence

- Plan artifact: `items/0088-roadmap-closed-issue-sync-v0.md`
- Plan에서 벗어난 변경이 있다면 이유: 없음.

## Game Studio route

- Umbrella: N/A 사유: 게임 runtime/UI/asset 변경이 아니라 운영 roadmap/item 상태 동기화입니다.
- Specialist route: N/A 사유: playfield, HUD, Phaser, sprite pipeline 변경 없음.
- 적용한 playfield/HUD/playtest 기준: N/A 사유: 화면 변경 없음.
- Game Studio route에서 벗어난 변경이 있다면 이유: 운영 문서와 검증 스크립트 정리만 수행했습니다.

## 작업 checklist

- [x] Plan artifact의 수용 기준을 모두 확인했다.
- [x] 게임 기능/UI/에셋/QA 변경이면 Game Studio route를 기록했다. N/A 사유: 운영 문서 변경입니다.
- [x] UI/HUD 변경이면 `game-studio:game-ui-frontend` 기준으로 playfield 보호와 persistent HUD 밀도를 확인했다. N/A 사유: UI/HUD 변경 없음.
- [x] 게임 화면 QA이면 `game-studio:game-playtest` 기준으로 첫 actionable screen, main verbs, HUD readability, playfield obstruction을 확인했다. N/A 사유: 게임 화면 변경 없음.
- [x] UI/visual 변경이면 Browser Use 우선 QA를 시도하고 evidence 또는 blocker를 남겼다. N/A 사유: visual 변경 없음.
- [x] 필요한 문서/roadmap/dashboard/report를 갱신했다.
- [x] GitHub issue/PR/comment evidence를 축약 없이 남겼다.

## 사용자/운영자 가치

- 게임 가치: 새 gameplay는 없지만, 다음 개발 순서가 닫힌 작업으로 오염되지 않아 production급 개선 흐름이 덜 흔들립니다.
- 운영사 가치: GitHub issue 상태와 roadmap/item/dashboard/check gate가 같은 완료 상태를 보게 됩니다.

## Before / After 또는 Visual evidence

- Before: #135, #137, #140, #117, #89가 GitHub에서는 CLOSED인데 roadmap/item 일부가 active 상태였습니다.
- After: 해당 roadmap row와 item status가 done/completed로 동기화됐습니다.
- Browser Use evidence 또는 blocker: N/A 사유: runtime UI/visual 변경 없음.
- N/A 사유: 운영 문서/검증 gate 정리 PR입니다.

## Playable mode

- main 실행 명령: `npm run play:main` 후 필요 시 `npm run play:main:install`, 그리고 `cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174`
- 이 PR이 사람 플레이 환경을 막지 않는 이유: runtime code, assets, save/economy/content 계약을 변경하지 않습니다.

## 검증

- [x] `npm run check:ci` PASS
- [x] UI/visual 변경이면 Browser Use QA와 `npm run check:visual` 또는 명시 blocker + fallback PASS. N/A 사유: visual 변경 없음.

## 안전 범위

- [x] 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음
- [x] `ENABLE_AGENT_AUTOMERGE` 변경 없음
- [x] Branch protection 우회 없음

## 남은 위험

- GitHub issue가 닫힐 때 issue body checkbox까지 자동으로 확인하는 별도 자동화는 아직 없습니다. 이번 PR은 roadmap/item/check gate의 stale 상태를 정리합니다.

## 연결된 issue

Closes #156
