### PR TITLE
운영: 다음 작업 선택을 vertical slice 기준으로 고정

### DIFF
--- a/.codex/skills/seed-ops/SKILL.md
+++ b/.codex/skills/seed-ops/SKILL.md
@@ -15,6 +15,7 @@ description: 이상한 씨앗상회 프로젝트 전용 무한 운영모드. 사
 - 각 issue는 작은 승리, 수용 기준, 검증 명령, evidence, 남은 리스크를 남긴다.
 - issue 종료 전 GitHub issue 본문의 `## 수용 기준` 체크박스를 실제 검증 결과로 갱신한다. `Closes #id`는 issue를 닫을 뿐 체크박스를 채우지 않으므로 빈 체크박스가 남으면 완료 gate 실패다.
 - UI/visual 작업은 Browser Use `iab` 실기 QA를 먼저 시도한다. Node REPL `js` tool이 처음 보이지 않으면 fallback 전에 `tool_search`로 노출을 재확인한다.
+- 다음 issue 선택은 "safe small item"이 아니라 `docs/NORTH_STAR.md` 경쟁작 기준 Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md` vertical slice workflow를 우선한다. safety는 stop/approval gate이고, 제품 우선순위 기준이 아니다.
 
 ## Before implementation
 
@@ -22,8 +23,20 @@ description: 이상한 씨앗상회 프로젝트 전용 무한 운영모드. 사
 2. 게임 기능/UI/HUD/playfield/asset/QA issue는 `game-studio:game-studio`로 먼저 분류하고 specialist route를 고정한다.
 3. UI/HUD/layout은 `game-studio:game-ui-frontend`, browser-game QA는 `game-studio:game-playtest`, Phaser runtime은 `game-studio:phaser-2d-game`, simulation/render/UI boundary는 `game-studio:web-game-foundations`, 2D sprite/FX는 `game-studio:sprite-pipeline` 기준을 적용한다.
 4. 새 issue/work item은 구현 전에 `items/<id>.md` 또는 동등 문서에 `## Plan`과 `## Game Studio route`를 만든다.
-5. stop rule이 없는 한 완료 후 다음 issue를 plan-first로 선택한다.
+5. stop rule이 없는 한 완료 후 다음 production vertical slice 후보를 plan-first로 선택한다.
 6. 다음 issue로 넘어가기 전 닫힌 issue/PR metadata를 확인해 acceptance checkbox, 작업 checklist, Browser Use/visual evidence, main CI 링크가 비어 있지 않은지 검증한다.
+
+## Issue selection gate
+
+다음 게임 issue 후보는 아래 5개 축 중 최소 3개를 명시해야 한다.
+
+1. `player verb`: 플레이어가 새로 하거나 더 명확히 이해하는 행동.
+2. `production/progression role`: 생산 엔진, 주문/납품, 업그레이드, 오프라인 복귀, 연구/원정, 수집 progression 중 연결되는 위치.
+3. `screen moment`: 첫 5분 또는 복귀 후 30초 안에서 보이는 실제 화면 순간.
+4. `asset/FX`: 필요한 생명체/주문/자원/피드백 asset 또는 기존 asset 활용 계획.
+5. `playtest evidence`: Browser Use/visual QA/수치 검증으로 확인할 사용자 관찰 포인트.
+
+색, 여백, 문구, 테스트-only, 문서-only 작업은 위 vertical slice를 막는 blocker를 제거하거나 명확한 slice 일부일 때만 고른다. `safe`, `local`, `작다`는 선택 이유가 될 수 없고, 오직 승인/파괴/외부 권한 gate를 통과했다는 조건으로만 사용한다.
 
 ## Product-quality gates
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ For game work, use the Game Studio plugin as the product-quality routing layer b
 - Track meaningful work in `docs/ROADMAP.md` until a richer `items/` system exists.
 - 프로젝트 전용 명령어는 `docs/PROJECT_COMMANDS.md`를 따른다. `$seed-ops`는 무한 운영모드, `$seed-brief`는 보고/상황판, `$seed-design`은 설계 대화, `$seed-qa`는 실기 QA, `$seed-play`는 사람 플레이 준비다.
 - Issue/work-item 단위 작업은 반드시 plan-first로 시작한다. 새 issue를 선택하면 코드/문서 구현 전에 `items/<id>.md` 또는 동등한 plan artifact에 `## Plan`, 수용 기준, 검증 명령, 리스크를 적고 그 plan에 맞춰 branch 작업을 시작한다.
+- 다음 issue 선택은 "안전하고 작은 작업" 우선이 아니라 `docs/NORTH_STAR.md`의 경쟁작 기준 Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md`의 vertical slice workflow 우선이다. safety는 금지/승인/복구 gate일 뿐 우선순위 기준이 아니다.
+- `$seed-ops`가 새 게임 issue를 고를 때는 `player verb + production/progression role + screen moment + asset/FX + playtest evidence` 중 최소 3개가 있는 후보를 먼저 고른다. 색/여백/문구/테스트-only 작업은 production vertical slice blocker를 제거하거나 명확한 slice 일부일 때만 선택한다.
 - 게임 기능/UI/에셋/QA issue는 plan-first 전에 Game Studio route를 고정한다. 최소 `game-studio:game-studio` umbrella 판단과 specialist route(`game-ui-frontend`, `game-playtest`, `phaser-2d-game`, `web-game-foundations`, `sprite-pipeline` 등)를 기록한다.
 - UI/visual acceptance는 `docs/GAME_UI_UX_RESEARCH_20260428.md`, `docs/IDLE_CORE_CREATIVE_GUIDE.md`, `docs/DESIGN_SYSTEM.md`의 북극성과 Game Studio rules를 기준으로 삼는다. “겹치지 않음”만으로는 통과가 아니며, 첫 화면이 게임 장면으로 읽히고 즉시 행동이 명확해야 한다.
 - UI/visual 회귀는 사용자 화면 기준이다. DOM에 텍스트가 있거나 Playwright assertion이 통과해도, 스크린샷에서 카드 내부가 잘리거나 하단 탭에 가리면 실패로 처리하고 source-of-truth 문서와 테스트를 같이 고친다.
@@ -87,7 +89,7 @@ For game work, use the Game Studio plugin as the product-quality routing layer b
 - GitHub issue/PR/comment 본문은 운영사 evidence surface다. `gh issue create/edit`, `gh pr create/edit`, `gh issue comment`, `gh api .../comments`를 사용할 때 본문은 반드시 markdown 파일로 작성하고 `--body-file` 또는 API file payload로 제출한다. 셸 인자 안에 `\n`을 넣어 본문을 만들지 않는다.
 - PR/issue/comment는 기존 `.github` 템플릿의 `요약`, `Small win`, `사용자/운영자 가치`, `Before / After 또는 Visual evidence`, `Playable mode`, `검증`, `안전 범위`, `남은 위험`, `연결된 issue` 수준을 유지한다. 짧은 PR도 해당 없음 사유를 적고 섹션을 삭제하지 않는다.
 - PR 본문의 `작업 checklist`는 삭제하지 않는다. UI/visual 변경이면 Browser Use 우선 QA evidence 또는 blocker를 남기고, Playwright/CDP는 fallback으로만 기록한다.
-- Do not stop at a milestone boundary when `docs/ROADMAP.md` names a clear next action and the next action is safe, local, and non-destructive.
+- Do not stop at a milestone boundary when `docs/ROADMAP.md` names a clear North Star vertical slice candidate and the next action is non-destructive and not externally gated.
 - A progress report is not a handoff. Continue through the current roadmap chain until the next step is blocked, destructive, requires credentials/network approval, or needs a product decision.
 - If a task touches payments, external deployment, credentials, policy-sensitive monetization, destructive migration, or production user data, stop for explicit approval.
 
@@ -109,7 +111,7 @@ When executing roadmap work:
 1. Complete the requested step.
 2. Verify its acceptance criteria.
 3. Update `docs/ROADMAP.md`.
-4. If the updated `Current Next Action` is clear and safe, continue automatically.
+4. If the updated `Current Next Action` names a clear North Star vertical slice candidate and no stop rule applies, continue automatically.
 5. In long-running operator mode, treat summaries as checkpoints and immediately choose the next issue with a `## Plan`.
 6. Stop only when the next action is ambiguous, risky, destructive, externally gated, timeboxed, blocked, or explicitly paused by the user.
 

--- a/docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md
+++ b/docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md
@@ -156,11 +156,11 @@ PR이 red check 상태면 verify lane은 실패 job을 읽고, 로컬 재현을 
 
 장시간 `$ralph` 운영모드에서 **완료 보고는 중단 조건이 아니라 체크포인트**다. issue 하나가 `implementation -> local verification -> PR -> GitHub checks -> main merge`까지 닫히면 운영자는 최종 답변으로 세션을 닫지 않고 다음 중 하나를 즉시 기록해야 한다.
 
-1. 다음 issue를 plan-first로 선택하고 `items/<id>.md` 또는 동등 plan artifact에 `## Plan`을 쓴다.
+1. 다음 issue를 plan-first로 선택하고 `items/<id>.md` 또는 동등 plan artifact에 `## Plan`을 쓴다. 게임 issue는 `docs/NORTH_STAR.md` Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md` vertical slice workflow를 우선 적용한다.
 2. 이미 정해진 시간 상한에 도달했다는 final heartbeat/watchdog/daily report를 남긴다.
 3. 명시 중단, 외부 승인, 치명적 blocker, credential/destructive/production boundary 중 하나를 blocker report로 남긴다.
 
-즉, 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 완료 보고 다음 행동은 “요약 후 종료”가 아니라 **다음 issue를 plan-first로 선택**하는 것이다. 이 규칙은 사용자가 기대한 6~8시간 또는 향후 24시간 운영을 위해 completion gate 위에 얹히는 continuation watchdog으로 취급한다.
+즉, 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 완료 보고 다음 행동은 “요약 후 종료”가 아니라 **다음 issue를 plan-first로 선택**하는 것이다. 게임 작업에서는 이 선택이 "safe small item"이 아니라 production vertical slice 후보여야 한다. 이 규칙은 사용자가 기대한 6~8시간 또는 향후 24시간 운영을 위해 completion gate 위에 얹히는 continuation watchdog으로 취급한다.
 
 ### watchdog runner
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -46,7 +46,7 @@ Updated: 2026-04-30
 ## 다음 작업
 
 1. `docs/ROADMAP.md`의 Current Next Action과 `docs/OPERATOR_CONTROL_ROOM.md`의 active mission/small win/evidence/playable mode를 먼저 확인한다.
-2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 issue를 plan-first로 선택한다.
+2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 production vertical slice 후보를 plan-first로 선택한다.
 3. 사람이 게임을 확인해야 하면 `npm run play:main` 후 `../strange-seed-shop-play`에서 port 5174로 실행한다.
 4. 24h dry run은 heartbeat/watchdog/continuation gate가 green이고 main CI가 green인 뒤 시작한다.
 

--- a/docs/OPERATOR_CONTROL_ROOM.md
+++ b/docs/OPERATOR_CONTROL_ROOM.md
@@ -38,8 +38,8 @@ Applies to: 모든 장시간 `$ralph`, issue-to-PR loop, 24h dry run 전 운영
 | Evidence | 테스트, CI, report, screenshot 링크 |
 | Visual delta | before/after screenshot 또는 `N/A — 이유` |
 | Playable status | main 게임 실행 가능 여부와 명령 |
-| Next safe stop | 사람이 멈춰도 되는 다음 지점 |
-| Next queue | 이 작업 이후의 안전한 다음 작업 |
+| Next stop gate | 사람이 멈춰도 되는 다음 지점 또는 승인이 필요한 경계 |
+| Next vertical slice queue | 이 작업 이후의 북극성 vertical slice 후보 |
 
 ## Issue 작성 규칙
 
@@ -114,7 +114,7 @@ npm run dev -- --host 127.0.0.1 --port 5174
 5. Draft PR: control room 형식의 PR 본문.
 6. Ready/merge: required checks 통과 후 branch protection 우회 없이 merge.
 7. Main 확인: main CI + local `npm run check:all`.
-8. Dashboard/roadmap 갱신: 다음 safe queue를 명시.
+8. Dashboard/roadmap 갱신: 다음 vertical slice queue와 stop gate를 분리해 명시.
 
 ## 관련 리서치에서 가져온 원칙
 

--- a/docs/OPERATOR_RUNBOOK.md
+++ b/docs/OPERATOR_RUNBOOK.md
@@ -96,7 +96,7 @@ Stop a long-running operator session only when one of these is true:
 - A hard blocker has a written report and no safe recovery path remains.
 - The user explicitly says stop/cancel/abort.
 
-Do not stop only because a PR was merged, a local report was written, or a “completed work” summary is ready. 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 summary는 다음 issue로 이어지는 checkpoint이고, 다음 issue를 plan-first로 선택해야 한다.
+Do not stop only because a PR was merged, a local report was written, or a “completed work” summary is ready. 명시 중단, 시간 상한, 외부 승인, 치명적 blocker가 없으면 summary는 다음 issue로 이어지는 checkpoint이고, 다음 issue를 plan-first로 선택해야 한다. 게임 issue라면 `docs/NORTH_STAR.md` Production Bar 기준의 vertical slice 후보를 고르며, "안전하고 작은 작업"은 우선순위 기준이 아니다.
 
 Before stopping, record:
 

--- a/docs/PROJECT_COMMANDS.md
+++ b/docs/PROJECT_COMMANDS.md
@@ -27,7 +27,7 @@ Scope: `이상한 씨앗상회` + 에이전트 네이티브 게임 스튜디오/
 
 1. `docs/ROADMAP.md`, `docs/NORTH_STAR.md`, `docs/OPERATOR_CONTROL_ROOM.md`에서 현재 목표를 확인한다.
 2. 게임 기능/UI/에셋/QA issue이면 `game-studio:game-studio`로 먼저 분류하고, 즉시 specialist route를 고정한다.
-3. 다음 issue를 선택하거나 만든다.
+3. 다음 issue를 선택하거나 만든다. 이때 선택 기준은 "안전하고 작은 작업"이 아니라 `docs/NORTH_STAR.md`의 Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md`의 vertical slice workflow다.
 4. 구현 전에 `items/<id>.md` 또는 동등 문서에 `## Plan`, Game Studio route, 수용 기준, 검증 명령, 금지 범위를 적는다.
 5. branch에서 작업한다.
 6. 로컬 검증과 필요한 visual evidence를 남긴다. UI/visual 변경이면 Browser Use `iab` QA를 먼저 시도하고, 처음 도구가 보이지 않으면 `tool_search`로 Node REPL `js`를 lazy-load한 뒤 재시도한다.
@@ -48,6 +48,18 @@ Scope: `이상한 씨앗상회` + 에이전트 네이티브 게임 스튜디오/
 Game Studio route가 필요한 issue/PR에서 route가 비어 있으면 plan 미완성이다. UI/visual 변경에서 “DOM이 보임”, “viewport 안에 있음”, “겹치지 않음”만으로는 통과가 아니다. 첫 화면이 게임 장면으로 읽히고, player verb와 즉시 행동이 명확하며, playfield가 보호되어야 한다.
 
 사용자 screenshot으로 제보된 UI bug는 그 screenshot을 source-of-truth 재현 상태로 취급한다. 같은 URL, viewport, QA 파라미터, 클릭/탭 sequence를 재현해 before/after screenshot을 남기고, 같은 실패 mode를 잡는 자동 회귀 gate를 추가한다. 모바일 카드/패널은 DOM text visible만으로 통과시키지 않고 body scroll, 하단 탭 overlap, visible child overflow, `overflow: hidden`으로 가려진 내부 콘텐츠를 확인한다.
+
+### 다음 issue 선택 gate
+
+`$seed-ops`는 작은 기능 개선을 기본값으로 고르지 않는다. 새 게임 issue 후보는 아래 5개 중 최소 3개를 plan에 명시해야 한다.
+
+1. `player verb`: 플레이어가 새로 하거나 더 명확히 이해하는 행동.
+2. `production/progression role`: 생산 엔진, 주문/납품, 업그레이드, 오프라인 복귀, 연구/원정, 수집 progression 중 어느 위치를 강화하는지.
+3. `screen moment`: 첫 5분 또는 복귀 후 30초 안에서 실제로 보이는 장면.
+4. `asset/FX`: 필요한 gameplay asset/FX 또는 기존 asset 활용 계획.
+5. `playtest evidence`: Browser Use, visual QA, 수치 검증으로 볼 사용자 관찰 포인트.
+
+`safe`, `local`, `작다`는 선택 이유가 아니라 승인/파괴/외부 권한 gate를 통과했다는 조건이다. 색/여백/문구/test-only/doc-only 작업은 production vertical slice blocker를 제거하거나 명확한 vertical slice 일부일 때만 선택한다.
 
 ### 작업 종료 문서 갱신 규칙
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -278,17 +278,19 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 현재 운영모드는 **북극성 지속 운영 루프**다. P0가 끝나도 멈추지 않고 게임 북극성(첫 5분 귀여움/수집 욕구)과 운영사 북극성(issue intake -> plan -> 구현 -> 검증 -> PR -> CI 복구 -> follow-up evidence)을 향해 계속 진행한다. 완료 보고는 중단 조건이 아니라 체크포인트이며, 명시 중단/시간 상한/외부 승인/치명적 blocker가 없으면 다음 issue를 plan-first로 선택한다.
 
-즉시 다음 작업:
+즉시 다음 작업 선택 기준:
 
-1. 현재 P0.5 운영은 복귀 보상 -> 소비 -> 재심기 -> 다음 수집으로 이어지는 작은 vertical slice를 계속 닫는다.
-2. 다음 `$seed-ops` issue는 열린 GitHub issue가 없으면 plan-first로 새 small win을 만들고, 게임 core/UI/visual QA를 한 PR에서 닫는다.
-3. 우선순위는 첫 5분 귀여움/수집 욕구와 복귀 후 30초 안의 다음 행동을 직접 강화하는 작업이다.
-4. 운영사 인프라는 CI/QA/상태 이해가 게임 개발을 막을 때만 우선한다.
+1. 다음 `$seed-ops` issue는 `docs/NORTH_STAR.md`의 경쟁작 기준 Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md`의 vertical slice workflow를 먼저 적용한다.
+2. 새 후보는 `player verb + production/progression role + screen moment + asset/FX + playtest evidence` 중 최소 3개를 plan에 명시해야 한다.
+3. 우선순위는 복귀 micro-copy나 작은 기능 추가가 아니라 production idle loop의 가장 큰 빈칸을 메우는 vertical slice다. 현재 후보군은 생산 엔진 가시성, 주문/납품 반복성, 업그레이드 선택, 연구/원정 장기 메타, 오프라인 복귀 hook 중 하나를 실제 화면과 gameplay에 연결해야 한다.
+4. "safe/local/small"은 선택 기준이 아니다. 결제, 로그인, 외부 배포, credential, destructive boundary를 피하는 safety gate일 뿐이다.
+5. 운영사 인프라는 CI/QA/상태 이해가 위 production vertical slice 진행을 막을 때만 우선한다.
+6. 다음 작업을 시작하기 전 plan artifact는 reference teardown, creative brief, asset/FX 필요 여부, Browser Use/playtest evidence 계획을 포함해야 한다.
 
 ## Previous Next Action History
 
 
-`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report와 Issue #84 heartbeat daemon hardening은 merge 완료되었다. 현재 안전한 다음 작업은 Issue #87의 operator control room + playable mode를 PR로 검증·merge해 사람이 자동화 중에도 현재 mission과 게임 실행 상태를 즉시 파악하게 하는 것이다.
+`docs/NORTH_STAR.md`가 게임 프로젝트와 에이전트 네이티브 운영사 프로젝트의 공통 헌장으로 추가되었다. Issue #53의 4h supervised trial report와 Issue #84 heartbeat daemon hardening은 merge 완료되었다. 과거에는 Issue #87 operator control room + playable mode가 다음 운영사 정비 후보였지만, #159 이후 `$seed-ops`의 기본 다음 작업 선택은 경쟁작 기준 production vertical slice로 넘어간다.
 
 1. Starter sprite batch evidence는 `items/0017-starter-seed-sprite-pipeline-first-batch.md`와 `scripts/check-sprite-batch.mjs`에 고정되어 있으며, 게임 작업은 계속 **이름 있는 생명체 수집**과 첫 5분 재미를 우선한다.
 2. Issue #44 / PR #45는 첫 발견 이후 다음 미발견 deterministic creature 목표를 보여줘 “하나만 더” 수집 욕구를 강화했다.

--- a/items/0106-vertical-slice-selection-contract-v0.md
+++ b/items/0106-vertical-slice-selection-contract-v0.md
@@ -1,0 +1,43 @@
+# Vertical slice selection contract v0
+
+Status: completed
+Branch: `codex/vertical-slice-selection-contract`
+Issue: #192
+
+## Context
+
+#159는 #142 North Star production bar 완료 상태를 동기화하면서 `$seed-ops`가 이미 닫힌 문서 정렬을 다시 고르지 않고 다음 production vertical slice로 넘어가야 한다는 목적을 남겼다. 하지만 `AGENTS.md`, `$seed-ops`, `docs/PROJECT_COMMANDS.md`, `docs/ROADMAP.md`에는 여전히 "safe next issue", "작은 기능", "작은 vertical slice" 표현이 남아 있어 에이전트가 경쟁작 기준 production loop보다 안전한 micro-improvement를 고르기 쉽다.
+
+## Game Studio route
+
+- `game-studio:game-studio`: 다음 issue 선택 기준을 player verb, production/progression role, screen moment, asset/FX, playtest evidence로 재정렬한다.
+- Specialist route: N/A. 런타임 UI/에셋 변경이 아니라 운영 source-of-truth 보정이다.
+
+## Plan
+
+1. `AGENTS.md`의 continuation/next action 언어를 "safe local issue"에서 "North Star vertical slice candidate"로 바꾼다.
+2. `$seed-ops`와 `docs/PROJECT_COMMANDS.md`에 다음 issue 선택 scoring gate를 추가한다.
+3. `docs/ROADMAP.md`의 Current Next Action을 복귀 micro-improvement queue가 아니라 production idle loop gap scan으로 갱신한다.
+4. 운영 runbook/dashboard 안내가 다음 issue를 "안전한 작은 작업"으로 부르지 않도록 보정한다.
+5. 문서 checker와 CI를 실행한다.
+
+## Acceptance
+
+- [x] 다음 issue 선택 전 `docs/NORTH_STAR.md` production bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md` vertical slice workflow를 반드시 참조한다.
+- [x] "safe next issue"는 stop/safety gate 의미로만 남고, 우선순위 기준으로는 쓰이지 않는다.
+- [x] 새 issue 후보는 `player verb + production/progression role + screen moment + asset/FX + playtest evidence` 중 최소 3개를 명시해야 한다.
+- [x] 작은 기능 개선은 vertical slice blocker를 제거하거나 명확한 slice 일부일 때만 선택한다는 규칙이 운영 문서에 반복된다.
+- [x] `npm run check:docs`, `npm run check:project-commands`, `npm run check:operator`, `npm run check:ci`가 통과한다.
+
+## Verification
+
+- [x] `rg -n "safe next|next safe|안전한 다음|safe queue|safe small|작은 기능 개선|새 small win" AGENTS.md docs .codex/skills items/0106-vertical-slice-selection-contract-v0.md`
+- [x] `npm run update:dashboard`
+- [x] `npm run check:docs`
+- [x] `npm run check:project-commands`
+- [x] `npm run check:operator`
+- [x] `npm run check:ci`
+
+## Risks
+
+- 문서만 강해지고 실제 자동 선택 로직은 여전히 느슨할 수 있다. 후속으로 issue template/checker가 vertical slice fields를 강제하게 만들 수 있다.

--- a/scripts/check-operator-control-room.mjs
+++ b/scripts/check-operator-control-room.mjs
@@ -82,7 +82,8 @@ requirePhrases("scripts/operator-control-room.mjs", [
   "Open issues",
   "Playable mode",
   "Visual evidence rule",
-  "Next safe stop"
+  "Next stop gate",
+  "production vertical slice"
 ]);
 
 console.log(JSON.stringify({ ok: failures.length === 0, requiredPaths: requiredPaths.length, failures }, null, 2));

--- a/scripts/check-operator.mjs
+++ b/scripts/check-operator.mjs
@@ -248,7 +248,9 @@ requirePhrases("AGENTS.md", [
   "수용 기준",
   "검증 명령",
   "완료 보고는 중단 조건이 아니라 체크포인트",
-  "다음 issue를 plan-first로 선택"
+  "다음 issue를 plan-first로 선택",
+  "Production Bar",
+  "vertical slice workflow"
 ]);
 
 requirePhrases("docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md", [
@@ -259,6 +261,7 @@ requirePhrases("docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md", [
   "completion checkpoint / continuation watchdog",
   "완료 보고는 중단 조건이 아니라 체크포인트",
   "다음 issue를 plan-first로 선택",
+  "production vertical slice",
   "명시 중단, 시간 상한, 외부 승인, 치명적 blocker"
 ]);
 
@@ -268,6 +271,7 @@ requirePhrases("docs/OPERATOR_RUNBOOK.md", [
   "plan artifact with `## Plan`",
   "완료 보고는 중단 조건이 아니라 체크포인트",
   "다음 issue를 plan-first로 선택",
+  "Production Bar",
   "명시 중단, 시간 상한, 외부 승인, 치명적 blocker"
 ]);
 

--- a/scripts/operator-control-room.mjs
+++ b/scripts/operator-control-room.mjs
@@ -19,7 +19,8 @@ function read(filePath, fallback = "") {
 }
 
 const roadmap = read("docs/ROADMAP.md");
-const currentNext = roadmap.split("\n").find((line) => line.startsWith("`docs/NORTH_STAR.md`")) ?? "Current Next Action unavailable";
+const currentNextMatch = roadmap.match(/## Current Next Action\n\n([\s\S]*?)(?:\n## |\n# |\n$)/);
+const currentNext = currentNextMatch?.[1]?.trim() || "Current Next Action unavailable";
 const branch = tryRun("git", ["branch", "--show-current"]);
 const status = tryRun("git", ["status", "--short"]);
 const latestCommit = tryRun("git", ["log", "-1", "--oneline"]);
@@ -59,9 +60,9 @@ ${openIssues === "" || openIssues === "unavailable" ? "- unavailable or none" : 
 - UI/game PR: link before/after screenshots under \`reports/visual/\`.
 - Docs/scripts-only PR: write \`N/A — UI 변화 없음\` and link check output/report.
 
-## Next safe stop
+## Next stop gate
 
-Stop only after PR required checks, main CI, and local \`npm run check:all\` are green, or after a written blocker report.
+Stop only after PR required checks, main CI, and local \`npm run check:all\` are green, or after a written blocker report. The next work queue should name a North Star production vertical slice, not a merely safe small task.
 `;
 
 if (outputPath) {

--- a/scripts/update-dashboard.mjs
+++ b/scripts/update-dashboard.mjs
@@ -103,7 +103,7 @@ ${rows.map((row) => `| ${row[0]} | ${row[1]} | ${row[2]} |`).join("\n")}
 ## 다음 작업
 
 1. \`docs/ROADMAP.md\`의 Current Next Action과 \`docs/OPERATOR_CONTROL_ROOM.md\`의 active mission/small win/evidence/playable mode를 먼저 확인한다.
-2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 issue를 plan-first로 선택한다.
+2. 장시간 운영모드에서는 완료 보고를 세션 종료가 아니라 checkpoint로 취급하고, stop rule이 없으면 다음 production vertical slice 후보를 plan-first로 선택한다.
 3. 사람이 게임을 확인해야 하면 \`npm run play:main\` 후 \`../strange-seed-shop-play\`에서 port 5174로 실행한다.
 4. 24h dry run은 heartbeat/watchdog/continuation gate가 green이고 main CI가 green인 뒤 시작한다.
 


### PR DESCRIPTION
## 요약

#159 이후에도 일부 운영 지침이 `safe/local/small next issue`처럼 읽히던 문제를 고쳤다. 다음 작업 선택 기준을 `docs/NORTH_STAR.md`의 경쟁작 기준 Production Bar와 `docs/IDLE_CORE_CREATIVE_GUIDE.md`의 vertical slice workflow로 고정했다.

## Small win

- `$seed-ops`가 새 게임 issue를 고를 때 `player verb + production/progression role + screen moment + asset/FX + playtest evidence` 중 최소 3개를 요구한다.
- `safe`, `local`, `작다`는 선택 이유가 아니라 stop/approval boundary를 통과했다는 조건으로만 남겼다.

## Plan-first evidence

- Plan artifact: `items/0106-vertical-slice-selection-contract-v0.md`
- Plan에서 벗어난 변경이 있다면 이유: 없음.

## Game Studio route

- Umbrella: `game-studio:game-studio`
- Specialist route: N/A 사유: 런타임 UI/asset 변경이 아니라 운영 source-of-truth 보정이다.
- 적용한 playfield/HUD/playtest 기준: N/A 사유: 화면 변경 없음.

## 사용자/운영자 가치

- 사용자: 다음 개발이 작은 copy/button 개선보다 production idle loop의 큰 빈칸을 먼저 메운다.
- 운영자: completion 이후 issue selection이 안전성 표현에 끌리지 않고 북극성 vertical slice 기준을 참조한다.

## Before / After 또는 Visual evidence

- Before: `AGENTS.md`, `$seed-ops`, `PROJECT_COMMANDS`, `ROADMAP Current Next Action`, control room surfaces가 다음 작업을 safe/small queue로 읽히게 만들 수 있었다.
- After: 다음 issue 선택 gate가 `Production Bar`와 vertical slice scoring으로 고정됐다.
- Visual evidence: N/A. 런타임 UI 변경 없음.

## Playable mode

- main 실행 명령: `npm run play:main`, 필요 시 `cd ../strange-seed-shop-play && npm run dev -- --host 127.0.0.1 --port 5174`
- 이 PR이 사람 플레이 환경을 막지 않는 이유: 앱 runtime/save/economy/content를 변경하지 않는다.

## 작업 checklist

- [x] Plan artifact 작성: `items/0106-vertical-slice-selection-contract-v0.md`
- [x] Game Studio route 기록
- [x] 문서/roadmap/dashboard/script/checker 갱신
- [x] GitHub issue evidence 생성: #192
- [x] Browser Use evidence N/A 사유 기록: runtime UI 변경 없음

## 검증

- [x] `npm run update:dashboard`
- [x] `npm run check:docs`
- [x] `npm run check:project-commands`
- [x] `npm run check:operator`
- [x] `npm run check:control-room`
- [x] `npm run check:ci`

## 안전 범위

- 실제 결제, 로그인/account, ads SDK, 외부 배포, 고객 데이터, credential, 실채널 GTM 없음
- runtime save/economy/content 변경 없음
- 자동 merge 설정 변경 없음

## 남은 위험

- 실제 다음 production vertical slice 구현은 별도 issue에서 진행해야 한다.

Closes #192
