### PR TITLE
Lunar harvest closeout evidence

### DIFF
--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -38,7 +38,7 @@ Updated: 2026-05-01
 
 | 상태 | 개수 |
 | --- | ---: |
-| done | 98 |
+| done | 99 |
 | review | 63 |
 | todo | 2 |
 | blocked | 0 |

--- a/docs/OPERATOR_CONTROL_ROOM.md
+++ b/docs/OPERATOR_CONTROL_ROOM.md
@@ -3,11 +3,11 @@
 <!-- OPERATOR_CONTROL_ROOM_SNAPSHOT:START -->
 ## Live Snapshot
 
-Generated at: 2026-05-01T15:58:52.792Z
+Generated at: 2026-05-01T16:02:52.205Z
 
 ## Current mission
 
-현재 작업은 `items/0135-seed-ops-ralph-runner-bridge.md`의 **Seed ops Ralph runner bridge** 검증 완료분을 커밋하고, 이후 `0132` GitHub publication/PR/checks loop 또는 다음 plan-first issue로 이어가는 것이다.
+현재 작업은 `Lunar harvest creature payoff v0` closeout evidence를 main 기준으로 닫고, stop rule이 없으면 다음 P0.5 production vertical slice issue를 plan-first로 선택하는 것이다.
 
 현재 evidence:
 
@@ -17,6 +17,7 @@ Generated at: 2026-05-01T15:58:52.792Z
 - External reference: LangGraph/Temporal/Cloudflare long-running agent docs also checkpoint/state/replay/plan 중심이다.
 - New structural gate: `publication_gate`, `confirmation.channel`, `continuation.action`, `continuation.artifact_path`, `safe_local_work`, `stop_rule`.
 - New Ralph runner gate: `scripts/check-ralph-runner-bridge.mjs` reports current Codex App `$ralph` state as `prompt-side-only` and detached runner count as 0.
+- PR #267 merged and main CI run `25221623897` passed.
 - Existing quality phrases kept in the live gate: `Studio Campaign Gate`, `Codex native subagents`, `team mode`, `단순 주문 추가`, `copy tweak`, `test-only`.
 
 즉시 적용된 gate:
@@ -31,27 +32,27 @@ Generated at: 2026-05-01T15:58:52.792Z
 
 ## Local state
 
-- Branch: codex/0132-lunar-harvest-creature-payoff-v0
-- Latest commit: bd4dc13 달방울 수확 PR 게시 근거를 연결한다
+- Branch: main
+- Latest commit: 12aefc9 Merge pull request #267 from bborok1234/codex/0132-lunar-harvest-creature-payoff-v0
 - Dirty files: present
 
 ## Heartbeat
 
 - Source: .omx/state/operator-heartbeat.json
-- Timestamp: 2026-05-01T15:57:30.171Z
-- Phase: pr-checks-wait
+- Timestamp: 2026-05-01T16:02:40.729Z
+- Phase: main-ci-verified
 - Issue: #266
 - PR: #267
 - Item: items/0132-lunar-harvest-creature-payoff-v0.md
-- Next action: PR checks gate 대기: verify #267 checks then merge/main CI if green
+- Next action: closeout gate 준비: commit main CI evidence and create next issue plan artifact
 
 ## Open PRs
 
-- #267 draft Lunar harvest creature payoff v0 — https://github.com/bborok1234/strange-seed-shop/pull/267
+- unavailable or none
 
 ## Open issues
 
-- #266 Lunar harvest creature payoff v0 — https://github.com/bborok1234/strange-seed-shop/issues/266
+- unavailable or none
 
 ## Playable mode
 

--- a/docs/OPERATOR_CONTROL_ROOM.md
+++ b/docs/OPERATOR_CONTROL_ROOM.md
@@ -3,7 +3,7 @@
 <!-- OPERATOR_CONTROL_ROOM_SNAPSHOT:START -->
 ## Live Snapshot
 
-Generated at: 2026-05-01T16:02:52.205Z
+Generated at: 2026-05-01T16:04:37.781Z
 
 ## Current mission
 
@@ -32,19 +32,19 @@ Generated at: 2026-05-01T16:02:52.205Z
 
 ## Local state
 
-- Branch: main
-- Latest commit: 12aefc9 Merge pull request #267 from bborok1234/codex/0132-lunar-harvest-creature-payoff-v0
+- Branch: codex/0132-lunar-harvest-closeout
+- Latest commit: d437b30 달방울 수확 closeout을 main CI 기준으로 닫는다
 - Dirty files: present
 
 ## Heartbeat
 
 - Source: .omx/state/operator-heartbeat.json
-- Timestamp: 2026-05-01T16:02:40.729Z
-- Phase: main-ci-verified
+- Timestamp: 2026-05-01T16:04:28.660Z
+- Phase: closeout-pr-prep
 - Issue: #266
 - PR: #267
 - Item: items/0132-lunar-harvest-creature-payoff-v0.md
-- Next action: closeout gate 준비: commit main CI evidence and create next issue plan artifact
+- Next action: closeout PR gate 준비: push closeout branch and verify PR checks
 
 ## Open PRs
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,7 +60,7 @@ Goal: 현재 수집 UI 프로토타입을 production급 idle collection tycoon v
 | P0.5 studio campaign pass | done | Issue #257, PR #258, main CI `25217147915`, `items/0129-game-studio-ops-harness.md`, `reports/operations/game-studio-harness-reference-review-20260501.md` | 다음 게임 issue 선택이 직전 issue 인접 기능이 아니라 `P0.5 Idle Core + Creative Rescue` campaign source of truth에서 출발하고, 기획팀/리서치팀/아트팀/개발팀/검수팀/마케팅팀/고객지원팀 Game Studio Department Signoff, role-debate note, Subagent/Team Routing, reference teardown, creative brief, QA/playtest plan을 요구함 |
 | P0.5 studio campaign audit | review | Issue #260, draft PR #265, `items/0130-p05-studio-campaign-audit.md`, `reports/operations/p05-studio-campaign-audit-20260501.md`, Browser Use QA screenshots, `items/0132-lunar-harvest-creature-payoff-v0.md`, PR checks pass | 첫 5분 loop/production readability/asset-FX/QA coverage를 부서별로 감사했고, 다음 tranche를 `Lunar harvest creature payoff v0`로 고정함 |
 | Seed ops PR publication confirmation boundary | done | Draft PR #265, `items/0133-seed-ops-pr-publication-confirmation-boundary.md`, `reports/operations/seed-ops-pr-publication-confirmation-boundary-20260501.md`, `$seed-ops` docs/checker hardening, `npm run check:ci` pass, PR checks pass | Codex App action-time confirmation이 필요한 PR/issue/comment publication을 terminal stop으로 취급하지 않고, `pending external-publication gate`와 `next local safe work`를 기록한 뒤 계속 진행하게 만듦 |
-| Lunar harvest creature payoff v0 | active | Issue #266, PR #267 checks pass, `items/0132-lunar-harvest-creature-payoff-v0.md`, `reports/visual/lunar-harvest-creature-payoff-v0-20260501.md`, Browser Use QA screenshots, accepted raster FX reuse binding, local asset/content gates pass | `달방울 씨앗` 수확 뒤 `달방울 누누`가 named reveal에서 끝나지 않고 production card/playfield actor/roster에 lunar work-state로 합류한다 |
+| Lunar harvest creature payoff v0 | done | Issue #266 closed, PR #267 merged, main CI `25221623897`, `items/0132-lunar-harvest-creature-payoff-v0.md`, `reports/visual/lunar-harvest-creature-payoff-v0-20260501.md`, Browser Use QA screenshots, accepted raster FX reuse binding | `달방울 씨앗` 수확 뒤 `달방울 누누`가 named reveal에서 끝나지 않고 production card/playfield actor/roster에 lunar work-state로 합류한다 |
 | Seed ops final publication ask regression | done | Commit `ea782c5`, `items/0134-seed-ops-final-publication-ask-regression.md`, `reports/operations/ralph-state-contract-review-20260502.md`, `scripts/check-seed-ops-publication-gate-state.mjs`, `scripts/check-ops-live.mjs`, `npm run check:ci` pass | GitHub issue/PR 게시 경계에서 `final`로 확인을 묻는 패턴을 하네스 회귀로 고정하고, publication boundary를 `publication_gate`/`confirmation`/`continuation` 구조화 heartbeat로 검증한다 |
 | Seed ops Ralph runner bridge | done | `items/0135-seed-ops-ralph-runner-bridge.md`, `scripts/check-ralph-runner-bridge.mjs`, `.codex/skills/seed-ops/SKILL.md`, `docs/PROJECT_COMMANDS.md`, `docs/OPERATOR_RUNBOOK.md`, `docs/AUTONOMOUS_PROJECT_OPERATING_MODEL.md`, `npm run check:ci` pass | Codex App prompt-side `$ralph` activation을 실제 detached `omx ralph`/`omx exec` long runner와 분리하고, lifecycle 판단을 assistant message 문구가 아니라 structured state, heartbeat, watchdog, runner artifact 기준으로 고정한다 |
 | Moon expedition reward bridge v0 | done | Issue #164, `items/0092-moon-expedition-reward-bridge-v0.md`, Browser Use QA, `reports/visual/p0-moon-expedition-reward-bridge-v0-20260429.md` | `달빛 흔적 찾기` 보상 수령이 `달방울 씨앗` / `달방울 누누` 다음 수집 목표로 이어짐 |
@@ -305,7 +305,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 
 ## Current Next Action
 
-현재 작업은 `items/0135-seed-ops-ralph-runner-bridge.md`의 **Seed ops Ralph runner bridge** 검증 완료분을 커밋하고, 이후 `0132` GitHub publication/PR/checks loop 또는 다음 plan-first issue로 이어가는 것이다.
+현재 작업은 `Lunar harvest creature payoff v0` closeout evidence를 main 기준으로 닫고, stop rule이 없으면 다음 P0.5 production vertical slice issue를 plan-first로 선택하는 것이다.
 
 현재 evidence:
 
@@ -315,6 +315,7 @@ Goal: only after Milestones 6-8 are proven, attempt a 24-hour bot that behaves l
 - External reference: LangGraph/Temporal/Cloudflare long-running agent docs also checkpoint/state/replay/plan 중심이다.
 - New structural gate: `publication_gate`, `confirmation.channel`, `continuation.action`, `continuation.artifact_path`, `safe_local_work`, `stop_rule`.
 - New Ralph runner gate: `scripts/check-ralph-runner-bridge.mjs` reports current Codex App `$ralph` state as `prompt-side-only` and detached runner count as 0.
+- PR #267 merged and main CI run `25221623897` passed.
 - Existing quality phrases kept in the live gate: `Studio Campaign Gate`, `Codex native subagents`, `team mode`, `단순 주문 추가`, `copy tweak`, `test-only`.
 
 즉시 적용된 gate:

--- a/items/0132-lunar-harvest-creature-payoff-v0.md
+++ b/items/0132-lunar-harvest-creature-payoff-v0.md
@@ -1,6 +1,6 @@
 # Lunar harvest creature payoff v0
 
-Status: verified
+Status: done
 Owner: agent
 Created: 2026-05-01
 Updated: 2026-05-01
@@ -134,6 +134,8 @@ Do not split write scopes until the asset list is final. Avoid parallel edits to
 - `npm run check:visual -- --grep "달빛 씨앗"` - pass
 - `npm run check:ci` - pass
 - GitHub PR #267 checks - pass (`Check automerge eligibility`, `Verify game baseline`)
+- PR #267 merged: merge commit `12aefc9`
+- main CI run `25221623897` - pass
 
 ## Risks
 

--- a/reports/operations/pr-0132-lunar-harvest-closeout-body.md
+++ b/reports/operations/pr-0132-lunar-harvest-closeout-body.md
@@ -1,0 +1,51 @@
+## 요약
+
+PR #267 merge 이후 main CI 성공 근거를 roadmap, item, PR body, operator control room에 반영합니다.
+
+## Small win
+
+`Lunar harvest creature payoff v0`가 구현/PR checks/merge/main CI까지 닫힌 상태로 로컬 운영 문서에서도 읽힙니다.
+
+## 사용자/운영자 가치
+
+- 사용자: `달방울 누누` 수확 payoff가 main 기준으로 배포 가능한 상태임을 확인했습니다.
+- 운영자: seed-ops loop가 PR merge에서 멈추지 않고 main CI evidence까지 닫는 계약을 유지합니다.
+
+## Before / After 또는 Visual evidence
+
+N/A - docs/evidence closeout only. 기존 visual evidence:
+
+- `reports/visual/lunar-harvest-payoff-before-browser-use-20260501.png`
+- `reports/visual/lunar-harvest-payoff-reveal-browser-use-20260501.png`
+- `reports/visual/lunar-harvest-payoff-production-browser-use-20260501.png`
+- `reports/visual/lunar-harvest-creature-payoff-v0-20260501.md`
+
+## Playable mode
+
+- Stable playable main: `http://127.0.0.1:5174` via `$seed-play` gate
+
+## 검증
+
+- [x] `gh run watch 25221623897 --exit-status`
+- [x] `npm run check:ci`
+
+## 작업 checklist
+
+- [x] PR #267 merge evidence 기록
+- [x] main CI run `25221623897` 기록
+- [x] Local CI pass
+- [ ] GitHub PR checks pass
+- [ ] main CI pass after merge
+
+## 안전 범위
+
+- 코드/런타임 변경 없음.
+- 실결제, 로그인, 외부 배포, 고객 데이터, 실제 GTM action 없음.
+
+## 남은 위험
+
+없음 - 다음 작업은 별도 P0.5 production vertical slice plan-first issue로 이어집니다.
+
+## 연결된 issue
+
+Follow-up closeout for #266 / #267.

--- a/reports/operations/pr-0132-lunar-harvest-creature-payoff-v0-body.md
+++ b/reports/operations/pr-0132-lunar-harvest-creature-payoff-v0-body.md
@@ -46,7 +46,7 @@ After:
 - [x] Browser Use 우선 QA evidence 기록
 - [x] Local CI pass
 - [x] GitHub PR checks pass
-- [ ] main CI pass after merge
+- [x] main CI pass after merge: run `25221623897`
 
 ## 안전 범위
 


### PR DESCRIPTION
## 요약

PR #267 merge 이후 main CI 성공 근거를 roadmap, item, PR body, operator control room에 반영합니다.

## Small win

`Lunar harvest creature payoff v0`가 구현/PR checks/merge/main CI까지 닫힌 상태로 로컬 운영 문서에서도 읽힙니다.

## 사용자/운영자 가치

- 사용자: `달방울 누누` 수확 payoff가 main 기준으로 배포 가능한 상태임을 확인했습니다.
- 운영자: seed-ops loop가 PR merge에서 멈추지 않고 main CI evidence까지 닫는 계약을 유지합니다.

## Before / After 또는 Visual evidence

N/A - docs/evidence closeout only. 기존 visual evidence:

- `reports/visual/lunar-harvest-payoff-before-browser-use-20260501.png`
- `reports/visual/lunar-harvest-payoff-reveal-browser-use-20260501.png`
- `reports/visual/lunar-harvest-payoff-production-browser-use-20260501.png`
- `reports/visual/lunar-harvest-creature-payoff-v0-20260501.md`

## Playable mode

- Stable playable main: `http://127.0.0.1:5174` via `$seed-play` gate

## 검증

- [x] `gh run watch 25221623897 --exit-status`
- [x] `npm run check:ci`

## 작업 checklist

- [x] PR #267 merge evidence 기록
- [x] main CI run `25221623897` 기록
- [x] Local CI pass
- [ ] GitHub PR checks pass
- [ ] main CI pass after merge

## 안전 범위

- 코드/런타임 변경 없음.
- 실결제, 로그인, 외부 배포, 고객 데이터, 실제 GTM action 없음.

## 남은 위험

없음 - 다음 작업은 별도 P0.5 production vertical slice plan-first issue로 이어집니다.

## 연결된 issue

Follow-up closeout for #266 / #267.
