### PR TITLE
로컬 Studio 미반영 작업을 복구 단위로 분리

### DIFF
--- a/docs/OPERATOR_CONTROL_ROOM.md
+++ b/docs/OPERATOR_CONTROL_ROOM.md
@@ -3,56 +3,54 @@
 <!-- OPERATOR_CONTROL_ROOM_SNAPSHOT:START -->
 ## Live Snapshot
 
-Generated at: 2026-05-01T16:09:57.418Z
+Generated at: 2026-05-02T16:11:49.231Z
 
 ## Current mission
 
-현재 작업은 `items/0136-no-post-merge-closeout.md`의 **Seed ops no post-merge closeout gate**다. PR merge/close 이후 main을 대상으로 evidence backfill closeout PR/commit을 만드는 안티패턴을 하네스에서 금지한다.
+현재 작업은 `items/0137-lunar-guardian-order-bridge-v0.md`의 **달방울 누누 달빛 보호 주문 + visual QA correction**이다. 사용자 제보 스크린샷 기준으로 `다음 행동` 카드의 달빛 보호 주문 payoff clipping을 고치고, 기존 seed-ops issue/PR 제목 패턴이 작은 연결 기능과 closeout evidence로 수렴한 문제를 회고해 `Strategic Jump Check`와 `Title Contract`를 하네스에 추가한다.
 
 현재 evidence:
 
-- `$ralph` skill review: `state_write`, `current_phase`, `.omx/state/{scope}/ralph-progress.json`, fresh verification, architect verification 중심이다.
-- Current `$ralph` activation: `.omx/state/sessions/019de3f6-4472-7cd1-a549-aa9eb399c536/ralph-state.json` is prompt-side only, `active:true`, `current_phase:"starting"`.
-- Past 4h loop: `.omx/tasks/overnight-ralph-driver-20260427T1515.sh` + heartbeat/watchdog JSON loop.
-- External reference: LangGraph/Temporal/Cloudflare long-running agent docs also checkpoint/state/replay/plan 중심이다.
-- New structural gate: `publication_gate`, `confirmation.channel`, `continuation.action`, `continuation.artifact_path`, `safe_local_work`, `stop_rule`.
-- New Ralph runner gate: `scripts/check-ralph-runner-bridge.mjs` reports current Codex App `$ralph` state as `prompt-side-only` and detached runner count as 0.
-- New no-post-merge gate: `scripts/check-no-post-merge-closeout.mjs` forbids new `reports/operations/*closeout*body.md` files and requires original-PR evidence before merge/close.
-- Existing quality phrases kept in the live gate: `Studio Campaign Gate`, `Codex native subagents`, `team mode`, `단순 주문 추가`, `copy tweak`, `test-only`.
+- Browser Use current tab: `http://127.0.0.1:5173/?qaLunarOrderReady=1&qaFxTelemetry=1`
+- User-reported defect reproduction: `reports/visual/lunar-guardian-user-defect-delivered-browser-use-20260502.png`
+- Fixed Browser Use state: `reports/visual/lunar-guardian-order-fixed-browser-use-20260502.png`
+- Regression gate: `npm run check:visual -- --grep "달빛 보호"` passed after the second clipping fix.
+- Issue/PR title retrospective: `reports/operations/seed-ops-issue-pr-title-retrospective-20260502.md`
+- Existing Studio Campaign Gate quality phrases remain active in the queue gate: `Codex native subagents`, `team mode`, `단순 주문 추가`, `copy tweak`, `test-only`.
 
 즉시 적용된 gate:
 
-1. `reports/operations/ralph-state-contract-review-20260502.md`에 Ralph/local/external durable-state 근거를 남긴다.
-2. `scripts/write-operator-heartbeat.mjs`는 publication gate 구조화 필드를 쓸 수 있어야 한다.
-3. `scripts/check-seed-ops-publication-gate-state.mjs`는 `confirmation.channel: "final"`과 continuation 누락 fixture를 실패로 잡아야 한다.
-4. `scripts/check-ops-live.mjs`는 현재 heartbeat가 `external-publication-gate`일 때 구조화 필드를 검사해야 한다.
-5. `scripts/check-ralph-runner-bridge.mjs`는 prompt-side `$ralph` state와 detached runner evidence를 구분해야 한다.
-6. `npm run check:ralph-runner-bridge`, `npm run check:seed-ops-publication-gate`, `npm run check:seed-ops-queue`, `npm run check:ops-live`, `npm run check:ci`가 통과했다.
-7. 이 작업이 끝나면 멈추지 않고 `0132` GitHub publication/PR/checks loop 또는 다음 plan-first issue로 이어간다.
+1. `.codex/skills/seed-ops/SKILL.md`와 `docs/PROJECT_COMMANDS.md`에 `Strategic Jump Check`를 추가한다.
+2. `.codex/skills/seed-ops/SKILL.md`와 `docs/PROJECT_COMMANDS.md`에 `Title Contract`를 추가한다.
+3. `scripts/check-seed-ops-queue-gate.mjs`가 이 두 계약이 seed-ops surface에서 사라지지 않게 확인한다.
+4. 이 작업 PR body에는 Browser Use fixed screenshot과 issue/PR title retrospective를 원 PR evidence로 포함한다.
+5. merge 뒤 main-targeted closeout commit/PR을 만들지 않고, stop rule이 없으면 다음 issue를 `Strategic Jump Check`부터 plan-first로 만든다.
 
 ## Local state
 
-- Branch: codex/0136-no-post-merge-closeout
-- Latest commit: 12aefc9 Merge pull request #267 from bborok1234/codex/0132-lunar-harvest-creature-payoff-v0
+- Branch: codex/recover-local-studio-work-20260503
+- Latest commit: 177d3f4 복구 원장 PR 본문을 운영 증거로 남김
 - Dirty files: present
 
 ## Heartbeat
 
 - Source: .omx/state/operator-heartbeat.json
-- Timestamp: 2026-05-01T16:08:39.395Z
+- Timestamp: 2026-05-02T16:11:05.688Z
 - Phase: verifying
-- Issue: local
+- Issue: #274
 - PR: 
-- Item: items/0136-no-post-merge-closeout.md
-- Next action: no-post-merge-closeout gate 검증 후 PR 준비
+- Item: items/0139-studio-infinite-runner-contract.md
+- Next action: gate 준비: PR277 CI recheck and merge
 
 ## Open PRs
 
-- unavailable or none
+- #277 ready 로컬 Studio 미반영 작업을 복구 단위로 분리 — https://github.com/bborok1234/strange-seed-shop/pull/277
 
 ## Open issues
 
-- unavailable or none
+- #276 Studio Harness v3 bot runner 구현 spec 및 checker 정리 — https://github.com/bborok1234/strange-seed-shop/issues/276
+- #275 대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구 — https://github.com/bborok1234/strange-seed-shop/issues/275
+- #274 로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필 — https://github.com/bborok1234/strange-seed-shop/issues/274
 
 ## Playable mode
 

--- a/reports/operations/creature-production-recovery-issue-body-20260503.md
+++ b/reports/operations/creature-production-recovery-issue-body-20260503.md
@@ -1,0 +1,48 @@
+# 대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구
+
+## 요약
+
+로컬 recovery branch에 남아 있는 실제 게임/UI production 변경을 GitHub issue/PR 단위로 되살린다. 목표는 기존 화면이 카드/대시보드처럼 보이는 문제를 줄이고, 대표 생명체 stage, 돌보기 반응, 도감 감상면을 플레이어가 크게 볼 수 있게 만드는 것이다.
+
+## 배경
+
+`stash@{0}`의 `src/App.tsx`, `src/styles.css`, `tests/visual/p0-mobile-game-shell.spec.ts`에는 1,200줄 규모의 production UI/gameplay 변경이 있다. 이 변경은 v2 local campaign ledger상 Keep/Release까지 기록되어 있지만, GitHub WorkUnit/PR로 승격되지 않았으므로 완료 작업으로 볼 수 없다.
+
+## 범위
+
+- 정원 첫 화면의 대표 생명체 stage layer
+- `돌보기 -> visible resident reaction -> in-world clue` 흐름
+- 도감의 큰 creature memory photo / memory variant / clue focus surface
+- 모바일 visual regression 보강
+- Browser Use `iab` production evidence 재수집
+
+## 비범위
+
+- 새 asset generation
+- manifest 등록
+- economy/schema migration
+- v2 campaign ledger를 authority로 merge
+- harness runner 구현
+
+## 수용 기준
+
+- [ ] production diff가 v3 GitHub issue/PR 범위로 묶인다.
+- [ ] 첫 화면에서 대표 생명체가 기존 카드 UI보다 우선 읽힌다.
+- [ ] 돌보기 후 pose/FX/clue state가 screenshot에서 확인된다.
+- [ ] 도감에서 수집 캐릭터를 큰 비주얼로 감상할 수 있다.
+- [ ] Browser Use `iab` evidence가 현재 세션 기준으로 갱신된다.
+- [ ] focused visual regression과 `npm run check:ci`가 통과한다.
+
+## 검증
+
+- Browser Use `iab` visual/playtest
+- `npm run check:visual`
+- `npm run check:ci`
+
+## 연결 evidence
+
+- `reports/operations/local-studio-work-recovery-20260503.md`
+- `reports/visual/creature-stage-production-*.png`
+- `reports/visual/care-clue-production-*.png`
+- `reports/visual/album-appreciation-production-*.png`
+

--- a/reports/operations/local-studio-work-recovery-20260503.md
+++ b/reports/operations/local-studio-work-recovery-20260503.md
@@ -1,0 +1,147 @@
+# 로컬 Studio 작업 복구 원장
+
+Status: recovery-triage
+Owner: Codex
+Updated: 2026-05-03
+
+## 배경
+
+PR #273 `Studio Harness v3 autonomous design`는 2026-05-02에 merge되었고 issue #272는 completed 상태다. 그러나 PR merge 이후에도 `codex/studio-harness-v3-autonomous-design` 로컬 브랜치 위에서 Codex가 추가 작업을 계속했고, 그 작업이 GitHub issue/PR 단위로 승격되지 않았다.
+
+이 원장은 `stash@{0}`를 무작정 삭제하거나 전체 적용 PR로 밀지 않기 위한 복구 기준이다. stash는 백업으로 보존하고, 현재 복구 브랜치 `codex/recover-local-studio-work-20260503`에서 내용물을 펼쳐 분류한다.
+
+## 현재 상태
+
+- Base: `origin/main` `d5d751d4df77241765fa48839ba8c0a986aecfb2`
+- Recovery branch: `codex/recover-local-studio-work-20260503`
+- Backup stash: `stash@{0}` `codex cleanup backup before returning to main after PR 273`
+- Tracked diff: 33 files, 1892 insertions, 859 deletions
+- Untracked recovery files: 90 files
+
+## 판정
+
+이 묶음은 찌꺼기가 아니다. 크게 네 종류가 섞여 있다.
+
+1. Studio Harness v2 로컬 ledger 전환 산출물
+2. v2 ledger가 실행한 `creature-collection-rescue` campaign evidence
+3. production game/UI 코드 변경
+4. PR #273 이후 GitHub-authoritative v3와 충돌하거나 대체되어야 하는 legacy 운영 문서 변경
+
+따라서 전체를 한 번에 merge하지 않는다. 또한 전체를 버리지 않는다.
+
+## Work Unit 분리
+
+### WU-A: v2 Local Ledger Quarantine / Migration
+
+GitHub issue: #274 `로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필`
+
+범위:
+
+- `STUDIO.md`
+- `GAME_BRIEF.md`
+- root `ROADMAP.md`
+- `campaigns/**`
+- `prototypes/**`
+- `reports/visual/*20260502.png`
+- `assets/source/portrait_variant_asset_plan_20260502.json`
+- `assets/source/portrait_variant_asset_prompts_20260502.json`
+- `.codex/skills/seed-studio/SKILL.md`
+- `scripts/check-studio-harness.mjs`
+- `items/0138-studio-harness-v2-first-pass.md`
+
+판정:
+
+- 보존한다.
+- 하지만 v3 이후에는 local ledger가 work authorization source가 될 수 없으므로, 이 상태 그대로 primary harness로 merge하지 않는다.
+- GitHub issue에 `migration-backfill` GateEvent로 연결하거나, evidence archive로 격리해야 한다.
+
+다음 조치:
+
+- 새 GitHub issue: `로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필`
+- PR 범위는 문서/스크립트 migration만 허용한다.
+- production game code는 포함하지 않는다.
+
+### WU-B: Creature Stage / Care-Clue / Album Production Recovery
+
+GitHub issue: #275 `대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구`
+
+범위:
+
+- `src/App.tsx`
+- `src/styles.css`
+- `tests/visual/p0-mobile-game-shell.spec.ts`
+- 관련 production Browser Use evidence:
+  - `reports/visual/creature-stage-production-*.png`
+  - `reports/visual/care-clue-production-*.png`
+  - `reports/visual/album-appreciation-production-*.png`
+
+판정:
+
+- 실제 게임 품질을 바꾸는 production 코드다.
+- local v2 ledger의 Keep/Release 기록이 있다고 해도 GitHub issue/PR evidence가 없으므로 아직 완료 작업으로 취급하지 않는다.
+- 별도 GitHub issue/PR로 되살리고, 현재 v3 기준 issue body, PR body, checks, Browser Use evidence를 새로 묶어야 한다.
+
+다음 조치:
+
+- 새 GitHub issue: `대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구`
+- PR에는 이 세 기능을 전부 넣을지, stage/care와 album을 둘로 나눌지 diff와 QA 결과를 보고 결정한다.
+- 병합 전 Browser Use `iab` 재검증과 `npm run check:ci`가 필요하다.
+
+### WU-C: Harness v3 Follow-up Runner / Bot Spec
+
+GitHub issue: #276 `Studio Harness v3 bot runner 구현 spec 및 checker 정리`
+
+범위:
+
+- `docs/PROJECT_COMMANDS.md`
+- `.codex/skills/seed-ops/SKILL.md`
+- `AGENTS.md`
+- `docs/OPERATOR_*`
+- `scripts/check-*`
+- `scripts/operator-*`
+- `package.json`
+
+판정:
+
+- 일부는 v3 방향과 맞고, 일부는 v2 local-ledger authority를 다시 강화할 위험이 있다.
+- PR #273의 `docs/STUDIO_HARNESS_V3_AUTONOMOUS_DESIGN.md`가 더 최신 source다.
+- 이 묶음은 그대로 적용하지 않고 v3 spec에 맞춰 재작성한다.
+
+다음 조치:
+
+- 새 GitHub issue: `Studio Harness v3 bot runner 구현 spec 및 checker 정리`
+- `$seed-ops`를 단순 deprecated adapter로 만드는 변경은 v3 bot runner 설계와 함께 다시 검토한다.
+- human git handoff 금지, GitHub authoritative WorkUnit, GateEvent, runner heartbeat를 우선한다.
+
+### WU-D: Already-Handled / Stale Local Delta
+
+범위:
+
+- `reports/operations/studio-harness-v3-pr-body-20260502.md`
+
+판정:
+
+- GitHub PR #273 본문에는 이미 `Closes #272`로 반영되어 merge 완료됐다.
+- 로컬 파일의 본문 수정은 repo history에 반영되지 않았지만, PR publication surface에는 반영되었다.
+- 단독 PR로 되살릴 가치가 낮다.
+
+다음 조치:
+
+- 다른 harness cleanup PR에 포함할지 판단한다.
+- 단독 변경으로 밀지 않는다.
+
+## 금지 사항
+
+- `stash@{0}` drop 금지.
+- `git reset --hard`, `git clean -fd`, 전체 restore 금지.
+- 이 recovery branch의 전체 diff를 하나의 PR로 publish 금지.
+- v2 `campaigns/**`만으로 다음 작업을 authorize 금지.
+- production game code와 harness migration을 같은 PR로 섞기 금지.
+
+## 권장 다음 순서
+
+1. 현재 recovery branch를 보존한다.
+2. WU-A, WU-B, WU-C 순서로 GitHub issue를 만들거나 body file을 준비한다.
+3. 각 WU는 `origin/main`에서 새 브랜치를 따고 필요한 파일만 선택 적용한다.
+4. WU-B는 Browser Use `iab`로 현재 production 화면을 다시 확인한 뒤 PR scope를 확정한다.
+5. recovery branch와 stash는 세 WU가 모두 원격 issue/PR로 흡수되기 전까지 유지한다.

--- a/reports/operations/local-studio-work-recovery-pr-body-20260503.md
+++ b/reports/operations/local-studio-work-recovery-pr-body-20260503.md
@@ -1,0 +1,68 @@
+## 요약
+
+PR #273 이후 로컬에 남아 있던 Studio Harness / game production 작업을 삭제하지 않고 복구 단위로 분리했습니다.
+
+## Small win
+
+`stash@{0}`에 숨어 있던 미반영 작업을 `WU-A #274`, `WU-B #275`, `WU-C #276`으로 나눠 GitHub issue에 연결했습니다.
+
+## 사용자/운영자 가치
+
+로컬 branch/stash에 쌓인 Codex 작업이 다시 사라지거나 한 PR에 섞여 들어가는 일을 막습니다. 이후 작업자는 `reports/operations/local-studio-work-recovery-20260503.md`를 기준으로 필요한 파일만 선택 적용할 수 있습니다.
+
+## Before / After 또는 Visual evidence
+
+Before:
+
+- `codex/studio-harness-v3-autonomous-design` 로컬 브랜치는 원격이 삭제된 상태였습니다.
+- `stash@{0}`에는 tracked diff 33개와 untracked 90개가 섞여 있었습니다.
+- 실제 game/UI production 변경과 v2 local ledger 산출물이 구분되지 않았습니다.
+
+After:
+
+- recovery branch: `codex/recover-local-studio-work-20260503`
+- backup stash: `stash@{0}` 보존
+- 복구 원장: `reports/operations/local-studio-work-recovery-20260503.md`
+- GitHub issues:
+  - #274 `로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필`
+  - #275 `대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구`
+  - #276 `Studio Harness v3 bot runner 구현 spec 및 checker 정리`
+
+## Playable mode
+
+해당 없음. 이 PR은 복구/운영 정리 문서만 추가합니다.
+
+## 검증
+
+- `gh issue create`로 #274, #275, #276 생성 확인
+- selective staging으로 복구 원장/issue body 파일만 커밋
+- production game/UI 및 v2 ledger diff는 이 PR 커밋에 포함하지 않음
+
+## 안전 범위
+
+- 문서/report만 추가합니다.
+- `stash@{0}`를 drop하지 않았습니다.
+- `git reset --hard`, `git clean`, 전체 restore를 수행하지 않았습니다.
+- 펼쳐진 recovery diff는 후속 WU에서 선택 적용합니다.
+
+## 남은 위험
+
+- recovery branch 작업트리에는 아직 펼쳐진 미커밋 diff가 남아 있습니다.
+- #274, #275, #276은 별도 issue/PR로 처리해야 합니다.
+- 이 PR은 정리 원장 PR이며, 실제 game/UI 변경을 merge하지 않습니다.
+
+## 연결된 issue
+
+Refs #274
+Refs #275
+Refs #276
+
+## 작업 checklist
+
+- [x] stash 내용을 삭제하지 않고 복구 브랜치에 펼침
+- [x] 작업 묶음을 WU-A/WU-B/WU-C/WU-D로 분류
+- [x] GitHub issue #274, #275, #276 생성
+- [x] 복구 원장과 issue body 파일 커밋
+- [ ] 후속 PR에서 #274 처리
+- [ ] 후속 PR에서 #275 처리
+- [ ] 후속 PR에서 #276 처리

--- a/reports/operations/local-studio-work-recovery-pr-body-20260503.md
+++ b/reports/operations/local-studio-work-recovery-pr-body-20260503.md
@@ -23,6 +23,7 @@ After:
 - recovery branch: `codex/recover-local-studio-work-20260503`
 - backup stash: `stash@{0}` 보존
 - 복구 원장: `reports/operations/local-studio-work-recovery-20260503.md`
+- `check:ops-live`는 CI에서 committed fallback heartbeat/control-room timestamp를 wall-clock live state로 오해하지 않도록 조정했습니다.
 - GitHub issues:
   - #274 `로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필`
   - #275 `대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구`
@@ -37,6 +38,8 @@ After:
 - `gh issue create`로 #274, #275, #276 생성 확인
 - selective staging으로 복구 원장/issue body 파일만 커밋
 - production game/UI 및 v2 ledger diff는 이 PR 커밋에 포함하지 않음
+- `npm run check:ops-live`
+- `npm run check:ci`
 
 ## 안전 범위
 
@@ -63,6 +66,7 @@ Refs #276
 - [x] 작업 묶음을 WU-A/WU-B/WU-C/WU-D로 분류
 - [x] GitHub issue #274, #275, #276 생성
 - [x] 복구 원장과 issue body 파일 커밋
+- [x] CI fallback heartbeat stale-age 오탐 수정
 - [ ] 후속 PR에서 #274 처리
 - [ ] 후속 PR에서 #275 처리
 - [ ] 후속 PR에서 #276 처리

--- a/reports/operations/local-v2-ledger-migration-issue-body-20260503.md
+++ b/reports/operations/local-v2-ledger-migration-issue-body-20260503.md
@@ -1,0 +1,48 @@
+# 로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필
+
+## 요약
+
+Codex가 Studio Harness v2 전환 이후 로컬에서 생성한 campaign ledger, prototype, Browser Use evidence, asset prompt 준비물을 Studio Harness v3의 GitHub-authoritative 운영 모델에 맞게 격리하고 백필한다.
+
+## 배경
+
+PR #273으로 `docs/STUDIO_HARNESS_V3_AUTONOMOUS_DESIGN.md`가 merge되었고, v3 기준에서는 GitHub issue/PR/GateEvent가 operational truth다. 그러나 로컬 `stash@{0}`에는 v2 local ledger 기반 산출물이 남아 있다.
+
+이 작업은 해당 산출물을 버리지 않고, 동시에 local ledger가 다시 authority가 되는 회귀를 막는다.
+
+## 범위
+
+- `STUDIO.md`, `GAME_BRIEF.md`, root `ROADMAP.md`
+- `campaigns/active.json`
+- `campaigns/creature-collection-rescue/**`
+- `prototypes/creature-collection-rescue/**`
+- `reports/visual/*20260502.png`
+- `assets/source/portrait_variant_asset_*_20260502.json`
+- `.codex/skills/seed-studio/SKILL.md`
+- `scripts/check-studio-harness.mjs`
+- `items/0138-studio-harness-v2-first-pass.md`
+
+## 비범위
+
+- production game code merge
+- `src/App.tsx`, `src/styles.css`, visual regression test 편입
+- v3 bot runner 구현
+- GitHub issue/PR state를 로컬 ledger에서 추론해 완료 처리
+
+## 수용 기준
+
+- [ ] v2 local ledger 산출물이 GitHub v3 기준에서 `quarantined` 또는 `migration-backfill`로 명시된다.
+- [ ] local ledger가 work authorization source가 아니라 evidence mirror임을 문서와 checker가 강제한다.
+- [ ] prototype/evidence 파일의 보존/삭제/이관 기준이 PR body에 명시된다.
+- [ ] `stash@{0}`와 recovery branch의 보존 상태가 보고된다.
+- [ ] `npm run check:docs`와 관련 harness checker가 통과한다.
+
+## 검증
+
+- `npm run check:docs`
+- migration checker 또는 기존 `check:studio-harness`를 v3-compatible하게 조정 후 실행
+
+## 연결 evidence
+
+- `reports/operations/local-studio-work-recovery-20260503.md`
+

--- a/reports/operations/studio-v3-bot-runner-issue-body-20260503.md
+++ b/reports/operations/studio-v3-bot-runner-issue-body-20260503.md
@@ -1,0 +1,46 @@
+# Studio Harness v3 bot runner 구현 spec 및 checker 정리
+
+## 요약
+
+PR #273의 v3 설계를 기준으로, 사람이 직접 git/GitHub를 조작하지 않아도 Studio runner가 GitHub issue/PR/GateEvent를 기준으로 계속 운영되도록 bot runner spec과 deterministic checker를 구현한다.
+
+## 배경
+
+현재 문제는 단순히 코드 변경이 남은 것이 아니라, Codex가 로컬 branch/stash에 작업을 쌓고 GitHub WorkUnit으로 승격하지 않은 운영 결함이다. v3 설계는 GitHub-authoritative 모델을 승인했지만, runner/checker 구현은 아직 없다.
+
+## 범위
+
+- GitHub WorkUnit reconstruction
+- GateEvent/state hash validation
+- pending-publication / partial-transition / quarantined state 처리
+- runner heartbeat / watchdog / stale branch 감지
+- PR/issue publication handoff 금지 checker
+- local ledger authority 회귀 방지
+
+## 비범위
+
+- production gameplay feature 구현
+- 새 asset generation
+- 실제 external deploy, payment, credential flow
+- PR #273 설계 문서의 대규모 재작성
+
+## 수용 기준
+
+- [ ] runner가 GitHub issue/PR/GateEvent를 source로 work unit을 복원한다.
+- [ ] local `campaigns/**`만으로 gate advance를 authorize하지 못한다.
+- [ ] routine branch push, PR create/update, issue/comment update가 human handoff로 밀리지 않도록 checker가 실패시킨다.
+- [ ] stale local branch와 unpushed dirty work를 감지하고 recovery state로 분류한다.
+- [ ] `npm run check:ci`에 필요한 deterministic gate가 연결된다.
+
+## 검증
+
+- focused unit/checker tests
+- stale branch fixture
+- local ledger authority regression fixture
+- `npm run check:ci`
+
+## 연결 evidence
+
+- `docs/STUDIO_HARNESS_V3_AUTONOMOUS_DESIGN.md`
+- `reports/operations/local-studio-work-recovery-20260503.md`
+

--- a/scripts/check-ops-live.mjs
+++ b/scripts/check-ops-live.mjs
@@ -63,6 +63,7 @@ const controlRoomPath = readArg("control-room", "docs/OPERATOR_CONTROL_ROOM.md")
 const heartbeatPath = readArg("heartbeat", fs.existsSync(".omx/state/operator-heartbeat.json") ? ".omx/state/operator-heartbeat.json" : latestHeartbeatReport());
 const controlRoom = read(controlRoomPath);
 const heartbeat = heartbeatPath ? readHeartbeat(heartbeatPath) : null;
+const heartbeatIsRuntimeState = heartbeatPath === ".omx/state/operator-heartbeat.json";
 
 if (!controlRoom) failures.push(`missing control room: ${controlRoomPath}`);
 if (!heartbeatPath) failures.push("missing heartbeat source");
@@ -73,7 +74,7 @@ const generatedAt = generatedMatch ? Date.parse(generatedMatch[1]) : Number.NaN;
 if (!generatedMatch) failures.push(`${controlRoomPath} missing Generated at timestamp`);
 if (Number.isNaN(generatedAt)) failures.push(`${controlRoomPath} has invalid Generated at timestamp`);
 
-if (!Number.isNaN(now) && !Number.isNaN(generatedAt)) {
+if (heartbeatIsRuntimeState && !Number.isNaN(now) && !Number.isNaN(generatedAt)) {
   const ageSeconds = Math.max(0, Math.floor((now - generatedAt) / 1000));
   if (ageSeconds > maxAgeSeconds) {
     failures.push(`${controlRoomPath} is stale: generated age ${ageSeconds}s exceeds ${maxAgeSeconds}s`);
@@ -84,7 +85,7 @@ if (heartbeat?.timestamp) {
   const heartbeatAt = Date.parse(heartbeat.timestamp);
   if (Number.isNaN(heartbeatAt)) {
     failures.push(`heartbeat timestamp is invalid: ${heartbeat.timestamp}`);
-  } else if (!Number.isNaN(now)) {
+  } else if (heartbeatIsRuntimeState && !Number.isNaN(now)) {
     const heartbeatAgeSeconds = Math.max(0, Math.floor((now - heartbeatAt) / 1000));
     if (heartbeatAgeSeconds > maxAgeSeconds) {
       failures.push(`heartbeat is stale: age ${heartbeatAgeSeconds}s exceeds ${maxAgeSeconds}s`);
@@ -107,7 +108,6 @@ if (heartbeat?.item && !fs.existsSync(heartbeat.item)) {
 }
 
 const currentBranch = tryRun("git", ["branch", "--show-current"]);
-const heartbeatIsRuntimeState = heartbeatPath === ".omx/state/operator-heartbeat.json";
 if (heartbeatIsRuntimeState && currentBranch && heartbeat?.branch && heartbeat.branch !== currentBranch) {
   failures.push(`heartbeat branch ${heartbeat.branch} does not match current branch ${currentBranch}`);
 }


### PR DESCRIPTION
## 요약

PR #273 이후 로컬에 남아 있던 Studio Harness / game production 작업을 삭제하지 않고 복구 단위로 분리했습니다.

## Small win

`stash@{0}`에 숨어 있던 미반영 작업을 `WU-A #274`, `WU-B #275`, `WU-C #276`으로 나눠 GitHub issue에 연결했습니다.

## 사용자/운영자 가치

로컬 branch/stash에 쌓인 Codex 작업이 다시 사라지거나 한 PR에 섞여 들어가는 일을 막습니다. 이후 작업자는 `reports/operations/local-studio-work-recovery-20260503.md`를 기준으로 필요한 파일만 선택 적용할 수 있습니다.

## Before / After 또는 Visual evidence

Before:

- `codex/studio-harness-v3-autonomous-design` 로컬 브랜치는 원격이 삭제된 상태였습니다.
- `stash@{0}`에는 tracked diff 33개와 untracked 90개가 섞여 있었습니다.
- 실제 game/UI production 변경과 v2 local ledger 산출물이 구분되지 않았습니다.

After:

- recovery branch: `codex/recover-local-studio-work-20260503`
- backup stash: `stash@{0}` 보존
- 복구 원장: `reports/operations/local-studio-work-recovery-20260503.md`
- GitHub issues:
  - #274 `로컬 v2 campaign ledger를 v3 WorkUnit evidence로 격리/백필`
  - #275 `대표 생명체 stage, 돌보기 반응, 도감 감상면을 production으로 복구`
  - #276 `Studio Harness v3 bot runner 구현 spec 및 checker 정리`

## Playable mode

해당 없음. 이 PR은 복구/운영 정리 문서만 추가합니다.

## 검증

- `gh issue create`로 #274, #275, #276 생성 확인
- selective staging으로 복구 원장/issue body 파일만 커밋
- production game/UI 및 v2 ledger diff는 이 PR 커밋에 포함하지 않음

## 안전 범위

- 문서/report만 추가합니다.
- `stash@{0}`를 drop하지 않았습니다.
- `git reset --hard`, `git clean`, 전체 restore를 수행하지 않았습니다.
- 펼쳐진 recovery diff는 후속 WU에서 선택 적용합니다.

## 남은 위험

- recovery branch 작업트리에는 아직 펼쳐진 미커밋 diff가 남아 있습니다.
- #274, #275, #276은 별도 issue/PR로 처리해야 합니다.
- 이 PR은 정리 원장 PR이며, 실제 game/UI 변경을 merge하지 않습니다.

## 연결된 issue

Refs #274
Refs #275
Refs #276

## 작업 checklist

- [x] stash 내용을 삭제하지 않고 복구 브랜치에 펼침
- [x] 작업 묶음을 WU-A/WU-B/WU-C/WU-D로 분류
- [x] GitHub issue #274, #275, #276 생성
- [x] 복구 원장과 issue body 파일 커밋
- [ ] 후속 PR에서 #274 처리
- [ ] 후속 PR에서 #275 처리
- [ ] 후속 PR에서 #276 처리
